### PR TITLE
Fikser bug med høyde på dropdown menyer for nettlesere som ikke støtter dvh-units

### DIFF
--- a/packages/client/src/styles/dropdown-menu.module.css
+++ b/packages/client/src/styles/dropdown-menu.module.css
@@ -25,8 +25,11 @@
     transition-property: max-height;
     transition-timing-function: ease-in-out;
     z-index: 1;
+    /* fallback to vh units for older browsers without dvh support */
     height: calc(100vh - var(--header-height) - 6rem);
-    height: calc(100dvh - var(--header-height));
+    @media (min-width: 0dvh) {
+        height: calc(100dvh - var(--header-height));
+    }
     overflow-y: auto;
     overscroll-behavior: contain;
 

--- a/packages/client/src/styles/dropdown-menu.module.css
+++ b/packages/client/src/styles/dropdown-menu.module.css
@@ -27,7 +27,7 @@
     z-index: 1;
     /* fallback to vh units for older browsers without dvh support */
     height: calc(100vh - var(--header-height) - 6rem);
-    @media (min-width: 0dvh) {
+    @media (min-height: 0dvh) {
         height: calc(100dvh - var(--header-height));
     }
     overflow-y: auto;


### PR DESCRIPTION
Har fått noen rapporter om at logg-ut knappen ikke er synlig for enkelte brukere. Antagelig gjelder det eldre nettlesere som mangler støtte for `dvh`-units. Tror dette skal fikse det.

`calc(100foounit - 100px)` er en gyldig verdi selv om `foounit` i seg selv ikke er det, så cascading'en funker ikke som tiltenkt her 😅 