### PR TITLE
Fikser bug ved bruk av handleInApp på breadcrumbs

### DIFF
--- a/packages/client/src/views/breadcrumbs.ts
+++ b/packages/client/src/views/breadcrumbs.ts
@@ -33,7 +33,7 @@ class Breadcrumbs extends HTMLElement {
                 source: "decorator",
                 event: "breadcrumbClick",
                 payload: {
-                    url: anchor.href,
+                    url: anchor.getAttribute("href"),
                     title: anchor.textContent?.trim() ?? "",
                     handleInApp: true,
                 },


### PR DESCRIPTION
Href-verdien på anchor-elementer er alltid en komplett url, uavhengig av hvilken attribute som ble satt. Dersom appene f.eks. har satt kun pathname, så blir payloaden fra callbacken ikke som forventet. `/myapp` får url `https://www.nav.no/myapp`.

Endrer til å bruke rå-verdien for href attributen, som skal være lik det som ble satt av appene.