### PR TITLE
Hindrer sticky-headeren fra å overlappe target posisjon ved programmatisk scrolling

### DIFF
--- a/packages/client/src/events.ts
+++ b/packages/client/src/events.ts
@@ -94,30 +94,18 @@ export const initHistoryEvents = () => {
 type ScrollArgs = [ScrollToOptions] | [x?: number, y?: number];
 
 // Emits events on programmatic scrolling
-export const initScrollEvents = () => {
-    // Skip this functionality for ancient browsers to avoid having to handle old scroll implementations
-    // Should be a very small % of users :D
-    if (!window.scrollTo) {
-        return;
-    }
-
-    const scrollActual = window.scroll.bind(window);
-    const scrollToActual = window.scrollTo.bind(window);
-    const scrollByActual = window.scrollBy.bind(window);
-
+export const initScrollToEvents = () => {
     const normalizeArgs = (...args: ScrollArgs) => {
         const [optionsOrXCoord, undefinedOrYCoord] = args;
+        const isOptions =
+            optionsOrXCoord && typeof optionsOrXCoord === "object";
 
-        const xCoord =
-            typeof optionsOrXCoord === "number"
-                ? optionsOrXCoord
-                : optionsOrXCoord?.left;
-        const yCoord =
-            typeof optionsOrXCoord === "number"
-                ? undefinedOrYCoord
-                : optionsOrXCoord?.top;
-
-        return { top: yCoord, left: xCoord };
+        return isOptions
+            ? { top: optionsOrXCoord.top, left: optionsOrXCoord.left }
+            : {
+                  top: undefinedOrYCoord,
+                  left: optionsOrXCoord,
+              };
     };
 
     const dispatchOnScrollTo = (...args: ScrollArgs) => {
@@ -138,6 +126,10 @@ export const initScrollEvents = () => {
             }),
         );
     };
+
+    const scrollActual = window.scroll.bind(window);
+    const scrollToActual = window.scrollTo.bind(window);
+    const scrollByActual = window.scrollBy.bind(window);
 
     window.scroll = ((...args: ScrollArgs) => {
         dispatchOnScrollTo(...args);

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,7 +1,7 @@
 /// <reference types="./client.d.ts" />
 import "vite/modulepreload-polyfill";
 import { initAnalytics } from "./analytics/analytics";
-import { initHistoryEvents, initScrollEvents } from "./events";
+import { initHistoryEvents, initScrollToEvents } from "./events";
 import { addFaroMetaData } from "./faro";
 import { refreshAuthData } from "./helpers/auth";
 import { buildHtmlElement } from "./helpers/html-element-builder";
@@ -37,7 +37,7 @@ const injectHeadAssets = () => {
 const init = () => {
     injectHeadAssets();
     initHistoryEvents();
-    initScrollEvents();
+    initScrollToEvents();
 
     if (param("maskHotjar")) {
         document.documentElement.setAttribute("data-hj-suppress", "");

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,7 +1,7 @@
 /// <reference types="./client.d.ts" />
 import "vite/modulepreload-polyfill";
 import { initAnalytics } from "./analytics/analytics";
-import { initHistoryEvents } from "./events";
+import { initHistoryEvents, initScrollEvents } from "./events";
 import { addFaroMetaData } from "./faro";
 import { refreshAuthData } from "./helpers/auth";
 import { buildHtmlElement } from "./helpers/html-element-builder";
@@ -37,6 +37,7 @@ const injectHeadAssets = () => {
 const init = () => {
     injectHeadAssets();
     initHistoryEvents();
+    initScrollEvents();
 
     if (param("maskHotjar")) {
         document.documentElement.setAttribute("data-hj-suppress", "");

--- a/packages/client/src/views/sticky.ts
+++ b/packages/client/src/views/sticky.ts
@@ -63,12 +63,8 @@ class Sticky extends HTMLElement {
         );
     };
 
-    private setFixed = (fixed: boolean) => {
-        if (fixed) {
-            this.fixedElement.classList.add(cls.fixed);
-        } else {
-            this.fixedElement.classList.remove(cls.fixed);
-        }
+    private setFixed = (isFixed: boolean) => {
+        this.fixedElement.classList.toggle(cls.fixed, isFixed);
     };
 
     // Set the header position to the top of the page and pause updates for a bit

--- a/packages/client/src/views/sticky.ts
+++ b/packages/client/src/views/sticky.ts
@@ -1,5 +1,6 @@
 import cls from "decorator-client/src/styles/sticky.module.css";
 import { defineCustomElement } from "./custom-elements";
+import { CustomEvents } from "../events";
 
 class Sticky extends HTMLElement {
     // This element is positioned relative to the top of the document and should
@@ -118,6 +119,20 @@ class Sticky extends HTMLElement {
         }
     };
 
+    private preventOverlapOnScrollTo = (
+        e: CustomEvent<CustomEvents["scrollTo"]>,
+    ) => {
+        if (typeof e.detail.top !== "number") {
+            return;
+        }
+
+        const isAboveHeader =
+            e.detail.top < this.getScrollPosition() + this.getHeaderHeight();
+        if (isAboveHeader) {
+            this.deferStickyBehaviour();
+        }
+    };
+
     private isElementAboveHeader = (element: HTMLElement) => {
         const scrollPos = this.getScrollPosition();
         const targetPos = scrollPos + element.getBoundingClientRect().top;
@@ -171,6 +186,7 @@ class Sticky extends HTMLElement {
         window.addEventListener("menuopened", this.onMenuOpen);
         window.addEventListener("menuclosed", this.onMenuClose);
 
+        window.addEventListener("scrollTo", this.preventOverlapOnScrollTo);
         document.addEventListener("focusin", this.preventOverlapOnFocusChange);
         document.addEventListener("click", this.preventOverlapOnAnchorClick);
     }
@@ -182,6 +198,7 @@ class Sticky extends HTMLElement {
         window.removeEventListener("menuopened", this.onMenuOpen);
         window.removeEventListener("menuclosed", this.onMenuClose);
 
+        window.removeEventListener("scrollTo", this.preventOverlapOnScrollTo);
         document.removeEventListener(
             "focusin",
             this.preventOverlapOnFocusChange,


### PR DESCRIPTION
Innfører et custom-event når scroll/scrollTo/scrollBy kalles, som sticky-headeren lytter på. Dersom scroll target er ovenfor headeren så vil headeren da skjules.