### PR TITLE
Amplitude logging skjermdeling + fiks typo i css-klasse search-hits

### DIFF
--- a/packages/client/src/views/screensharing-modal.ts
+++ b/packages/client/src/views/screensharing-modal.ts
@@ -4,6 +4,7 @@ import { env, param } from "../params";
 import clsInputs from "../styles/inputs.module.css";
 import { defineCustomElement } from "./custom-elements";
 import { isDialogDefined } from "../helpers/dialog-util";
+import { amplitudeEvent } from "../analytics/amplitude";
 
 let hasBeenOpened = false;
 
@@ -48,6 +49,11 @@ function startCall(code: string) {
         groupId: "A034081B-6B73-46B7-BE27-23B8E9CE3079",
         startCode: code,
     });
+    amplitudeEvent({
+        eventName: "skjermdeling",
+        kategori: "dekorator-footer",
+        komponent: "ScreensharingModal",
+    });
 }
 
 export class ScreensharingModal extends HTMLElement {
@@ -57,6 +63,21 @@ export class ScreensharingModal extends HTMLElement {
 
     showModal() {
         this.dialog.showModal();
+        amplitudeEvent({
+            eventName: "modal åpnet",
+            kategori: "dekorator-footer",
+            lenketekst: "Start skjermdeling",
+            komponent: "ScreensharingModal",
+        });
+    }
+    closeModal() {
+        this.dialog.close();
+        amplitudeEvent({
+            eventName: "modal lukket",
+            kategori: "dekorator-footer",
+            lenketekst: "Start skjermdeling",
+            komponent: "ScreensharingModal",
+        });
     }
 
     validateInput(code: string) {
@@ -92,13 +113,13 @@ export class ScreensharingModal extends HTMLElement {
             const code = new FormData(form).get("screensharing_code");
             if (typeof code === "string" && this.validateInput(code)) {
                 startCall(code);
-                this.dialog.close();
+                this.closeModal();
             }
         });
 
         this.querySelector("button[data-type=cancel]")?.addEventListener(
             "click",
-            () => this.dialog.close(),
+            () => this.closeModal(),
         );
     }
 }

--- a/packages/server/src/views/search-hits.ts
+++ b/packages/server/src/views/search-hits.ts
@@ -66,7 +66,7 @@ export const SearchHits = ({
                   >
                       ${i18n("more_hits")}
                       ${ArrowRightIcon({
-                          className: utils.icons,
+                          className: utils.icon,
                       })}
                   </a>
               `


### PR DESCRIPTION
- Legger til logging av `modal åpnet` og `modal lukket` for skjermdeling
- Start av en sesjon logges med et nytt event `skjermdeling`
- Fiks av typo i classname for icon i search-hits

Testet lokalt og i dev