### PR TITLE
Setter begrensning i søkefelt til 100 tegn

### DIFF
--- a/packages/server/src/views/search-form.ts
+++ b/packages/server/src/views/search-form.ts
@@ -15,6 +15,7 @@ export const SearchForm = () => {
                     class="${cls.searchInput}"
                     type="text"
                     name="search"
+                    maxlength="100"
                     id="${id}"
                     autocomplete="off"
                 />


### PR DESCRIPTION
Av personvernhensyn og som et sikkerhetsreduserende tiltak skal søkefeltet kun tillate 100 tegn.