### PR TITLE
Mocker funksjon og Promise dekoratorenAmplitude 

### DIFF
--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -4,6 +4,13 @@ import { Auth } from "decorator-shared/auth";
 
 const logPageViewCallback = (auth: Auth) => () => logPageView(auth);
 
+export const mockAmplitude = () =>
+    new Promise<any>((resolve, reject) => {
+        reject(
+            "Amplitude is not initialized. Please check for user analytics concent",
+        );
+    });
+
 export const initAnalytics = (auth: Auth) => {
     initAmplitude();
     initTaskAnalytics();
@@ -17,6 +24,8 @@ export const initAnalytics = (auth: Auth) => {
 export const stopAnalytics = (auth: Auth) => {
     stopAmplitude();
     stopTaskAnalytics();
+
+    window.dekoratorenAmplitude = mockAmplitude;
 
     // Pass the same function reference
     window.removeEventListener("historyPush", logPageViewCallback(auth));

--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -7,7 +7,7 @@ const logPageViewCallback = (auth: Auth) => () => logPageView(auth);
 export const mockAmplitude = () =>
     new Promise<any>((resolve, reject) => {
         reject(
-            "Amplitude is not initialized. Please check for user analytics concent",
+            "Amplitude is not initialized. Please check for user analytics consent",
         );
     });
 

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -80,6 +80,7 @@ const init = () => {
 
     refreshAuthData();
 
+    // Blir overskrevet dersom vi får ov til å starte Amplitude etter samtykke
     window.dekoratorenAmplitude = mockAmplitude;
 
     const { consent } = window.webStorageController.getCurrentConsent();

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,6 +1,10 @@
 /// <reference types="./client.d.ts" />
 import "vite/modulepreload-polyfill";
-import { initAnalytics, stopAnalytics } from "./analytics/analytics";
+import {
+    initAnalytics,
+    mockAmplitude,
+    stopAnalytics,
+} from "./analytics/analytics";
 import { initHistoryEvents, initScrollToEvents } from "./events";
 import { addFaroMetaData } from "./faro";
 import { refreshAuthData } from "./helpers/auth";
@@ -75,6 +79,8 @@ const init = () => {
     initConsentListener();
 
     refreshAuthData();
+
+    window.dekoratorenAmplitude = mockAmplitude;
 
     const { consent } = window.webStorageController.getCurrentConsent();
 

--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -106,10 +106,9 @@ export class WebStorageController {
     }
 
     private clearOptionalCookies(allOptionalStorage: PublicStorageItem[]) {
-        const storedCookies = document.cookie.split(";").map((cookie) => {
-            const [name, value] = cookie.trim().split("=");
-            return { name, value };
-        });
+        const storedCookies = Object.entries(Cookies.get()).map(
+            ([name, value]) => ({ name, value }),
+        );
 
         allOptionalStorage.forEach((storage) => {
             const optionalStorageBase = storage.name.replace(/\*$/, "");


### PR DESCRIPTION
Dersom Amplitude ikke er satt igang blir feil kastet når team forsøker å bruke objektet via en eldre versjon av nav-dekoratoren-moduler.

Testet i dev både med samtykke og ikke samtykke. Ved samtykke logger Amplitude som forventet.
