### PR TITLE
Resolve promise for mockAmplitude

### DIFF
--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -19,11 +19,7 @@ declare global {
 const logPageViewCallback = (auth: Auth) => () => logPageView(auth);
 
 export const mockAmplitude = () =>
-    new Promise<any>((resolve) => {
-        resolve(
-            "Amplitude is not initialized. Please check for user analytics consent",
-        );
-    });
+    Promise.resolve("Amplitude is disabled and mocked due to missing consent.");
 
 export const initAnalytics = (auth: Auth) => {
     initAmplitude();

--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -19,8 +19,8 @@ declare global {
 const logPageViewCallback = (auth: Auth) => () => logPageView(auth);
 
 export const mockAmplitude = () =>
-    new Promise<any>((resolve, reject) => {
-        reject(
+    new Promise<any>((resolve) => {
+        resolve(
             "Amplitude is not initialized. Please check for user analytics consent",
         );
     });


### PR DESCRIPTION
Mange team varsler om feil i Sentryloggene når Amplitude ikke resolver korrekt til en logger-funksjon. Teamene gjør slik og håndterer ofte ikke rejected promises, noe som skaper feil i loggene deres:

```
const logger = getAmplitudeInstance('foobar-context');
logger('sidebesøk')
```

Denne PR'en endrer slik at mockAmplitude (som settes dersom bruker ikke har samtykket til sporing) returnerer et promise som resolver istedet. Da vil bruk av feks `logger('sidebesøk')` bare forkaste loggingen i stillhet.

<img width="764" alt="logger" src="https://github.com/user-attachments/assets/c3c0d49c-b6d0-4a54-9726-676d0a35b625" />
