### PR TITLE
Bruker userAgents for å stoppe visning av cookie-banner

### DIFF
--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -206,16 +206,29 @@ export class WebStorageController {
         this.clearOptionalLocalAndSessionStorage(allOptionalStorage);
     }
 
+    private shouldDisableConsentBanner = (): boolean => {
+        const disabledPatterns = {
+            hostnames: ["oera.no", "cms-arkiv.ansatt", "siteimprove.com"],
+            userAgents: ["siteimprove.com"],
+        };
+
+        const hostnameMatched = disabledPatterns.hostnames.some((pattern) =>
+            window.location.hostname.includes(pattern),
+        );
+
+        const userAgentMatched = disabledPatterns.userAgents.some((pattern) =>
+            navigator.userAgent.includes(pattern),
+        );
+
+        return hostnameMatched || userAgentMatched;
+    };
+
     private checkAndTriggerConsentBanner() {
         const { userActionTaken, meta } = this.getCurrentConsent();
         const { version } = meta;
 
         // Don't show cookie banner for nav.no editors
-        if (
-            window.location.hostname.includes("oera.no") ||
-            window.location.hostname.includes("cms-arkiv.ansatt") ||
-            window.location.hostname.includes("siteimprove.com")
-        ) {
+        if (this.shouldDisableConsentBanner()) {
             return;
         }
 

--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -217,7 +217,7 @@ export class WebStorageController {
         );
 
         const userAgentMatched = disabledPatterns.userAgents.some((pattern) =>
-            navigator.userAgent.includes(pattern),
+            navigator.userAgent?.toLowerCase().includes(pattern),
         );
 
         return hostnameMatched || userAgentMatched;


### PR DESCRIPTION
Det ser ut til at Siteimprove kjører rendring av nav.no med javascript på serversiden før javascript skrelles vekk og siden presenteres i preview.

Foreslår å sjekke mot userAgent som Siteimprove selv [rapporterer](https://help.siteimprove.com/support/solutions/articles/80000448553-what-ip-addresses-and-user-agents-are-used-by-siteimprove-) at de bruker.

## Test
Testet i dev. Kan testes ved å feks sette opp custom User Agent string som denne:
`Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0) Image size by Siteimprove.com`

Da vises ikke cookie-banneret. (husk å slette evt navno-consent-cookie for å teste visning / ikke visning)