### PR TITLE
Forsøker å slette Date fra header hvor denne settes to ganger

### DIFF
--- a/packages/server/src/handlers/headers.ts
+++ b/packages/server/src/handlers/headers.ts
@@ -19,6 +19,7 @@ export const headers: MiddlewareHandler = async (c, next) => {
     await next();
 
     const origin = c.req.header("origin");
+    c.res.headers.delete("Date");
 
     if (isAllowedOrigin(origin)) {
         c.header("Access-Control-Allow-Origin", origin);


### PR DESCRIPTION
Grafana rapporterer om "upstream sent duplicate header line: "Date: Mon, 03 Mar 2025 13:04:28 GMT", previous value: "Date: Mon, 03 Mar 2025 13:04:29 GMT". Det er ikke noe vi gjør bevisst utover at vi har en middleware som setter diverse utløp. Forsøker på slette Date header for å se om feilen i Grafana løser seg, men usikker på om dette har noen virkning.