### PR TITLE
Legg til prefix på CSS layers

### DIFF
--- a/packages/client/src/main.css
+++ b/packages/client/src/main.css
@@ -17,9 +17,9 @@ body {
     overflow-y: scroll;
 }
 
-@layer base, utilities;
+@layer d-base, d-utilities;
 
-@layer base {
+@layer d-base {
     #decorator-header,
     #decorator-footer {
         --edge-spacing: var(--a-spacing-4);

--- a/packages/client/src/main.css
+++ b/packages/client/src/main.css
@@ -17,9 +17,9 @@ body {
     overflow-y: scroll;
 }
 
-@layer d-base, d-utilities;
+@layer dekorator-base, dekorator-utilities;
 
-@layer d-base {
+@layer dekorator-base {
     #decorator-header,
     #decorator-footer {
         --edge-spacing: var(--a-spacing-4);

--- a/packages/client/src/styles/utils.module.css
+++ b/packages/client/src/styles/utils.module.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer d-utilities {
     .contentContainer {
         width: 100%;
         max-width: 1440px;

--- a/packages/client/src/styles/utils.module.css
+++ b/packages/client/src/styles/utils.module.css
@@ -1,4 +1,4 @@
-@layer d-utilities {
+@layer dekorator-utilities {
     .contentContainer {
         width: 100%;
         max-width: 1440px;


### PR DESCRIPTION
Legger til `dekorator-` prefix for å unngå kollisjon med annen CSS som også bruker layers med navn som `base` og `utilities`.

Testet lokalt, og ser ingen visuelle endringer. Gjenstår å se om det gir ønsket resultat for team som bruker Tailwind eller lignende.