### PR TITLE
Fikser feil i padding på desktop

### DIFF
--- a/packages/client/src/main.css
+++ b/packages/client/src/main.css
@@ -46,7 +46,7 @@ body {
     @media (min-width: 1024px) {
         #decorator-header,
         #decorator-footer {
-            --edge-spacing: var(--a-spacing-10);
+            --edge-spacing: var(--a-spacing-12);
         }
     }
 }


### PR DESCRIPTION
Bytter fra Aksel spacing 10 til 12, for å fikse ulikhet i padding for innhold i og utenfor header på desktop. 
![image](https://github.com/user-attachments/assets/3a549417-6e8b-44b7-9b5e-a21c95971204)
