### PR TITLE
Legger til data-testid for knapper i cookiebanner

### DIFF
--- a/packages/server/src/views/consent-banner.ts
+++ b/packages/server/src/views/consent-banner.ts
@@ -49,6 +49,8 @@ export const ConsentBanner = ({ language }: ConsentBannerProps) => {
                             variant: "primary",
                             attributes: {
                                 ["data-name"]: "consent-banner-all",
+                                // data-testid brukes av Playwright i andre team for styring av cookiebanner
+                                // den må ikke endres uten at de andre teamene er informert
                                 ["data-testid"]: "consent-banner-all",
                             },
                             className: cls.button,

--- a/packages/server/src/views/consent-banner.ts
+++ b/packages/server/src/views/consent-banner.ts
@@ -47,7 +47,10 @@ export const ConsentBanner = ({ language }: ConsentBannerProps) => {
                         ${Button({
                             content: i18n("consent_banner_consent_all"),
                             variant: "primary",
-                            attributes: { ["data-name"]: "consent-banner-all" },
+                            attributes: {
+                                ["data-name"]: "consent-banner-all",
+                                ["data-testid"]: "consent-banner-all",
+                            },
                             className: cls.button,
                         })}
                         ${Button({
@@ -55,6 +58,8 @@ export const ConsentBanner = ({ language }: ConsentBannerProps) => {
                             variant: "primary",
                             attributes: {
                                 ["data-name"]: "consent-banner-refuse-optional",
+                                ["data-testid"]:
+                                    "consent-banner-refuse-optional",
                             },
                             className: cls.button,
                         })}


### PR DESCRIPTION
Oppdaterer`ConsentBanner` hvor begge knapper får sine egne "data-testid"-attributter for at Playwright og andre testverktøy kan styre cookiebanneret på en mer stabil måte.