### PR TITLE
Bedre React-safe måte å trigge samtykkebanner på

### DIFF
--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -128,6 +128,9 @@ export class WebStorageController {
         // Add click event listener to handle consent banner triggers
         document.addEventListener("click", (event) => {
             const target = event.target as Element;
+            if (!target || !(target instanceof Element)) {
+                return;
+            }
             const triggerElement = target.closest(
                 "[data-consent-banner-trigger]",
             );

--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -125,6 +125,18 @@ export class WebStorageController {
             "refuseOptionalWebStorage",
             this.refuseOptionalStorageHandler,
         );
+        // Add click event listener to handle consent banner triggers
+        document.addEventListener("click", (event) => {
+            const target = event.target as Element;
+            const triggerElement = target.closest(
+                "[data-consent-banner-trigger]",
+            );
+
+            if (triggerElement) {
+                event.preventDefault();
+                window.webStorageController.showConsentBanner();
+            }
+        });
     }
 
     private clearOptionalCookies(allOptionalStorage: PublicStorageItem[]) {

--- a/packages/server/src/menu/main-menu.ts
+++ b/packages/server/src/menu/main-menu.ts
@@ -196,13 +196,7 @@ const nodeToLinkGroup: (node: MenuNode) => LinkGroup = ({
     children: children.map(nodeToLink),
 });
 
-const getUrl = (
-    path: string | undefined,
-    frontendEventID: string | undefined,
-) => {
-    if (frontendEventID?.toUpperCase() === "ENDRE_COOKIE_SAMTYKKE") {
-        return `javascript:window.webStorageController.showConsentBanner()`;
-    }
+const getUrl = (path: string | undefined) => {
     return path?.startsWith("http") ? path : `${env.XP_BASE_URL}${path ?? ""}`;
 };
 
@@ -212,7 +206,11 @@ const nodeToLink: (node: MenuNode) => Link = ({
     frontendEventID,
 }) => ({
     content: displayName,
-    url: getUrl(path, frontendEventID),
+    url: getUrl(path),
+    attributes:
+        frontendEventID?.toUpperCase() === "ENDRE_COOKIE_SAMTYKKE"
+            ? { "data-consent-banner-trigger": "true" }
+            : undefined,
 });
 
 const getContextKey = (context: Context) => {

--- a/packages/server/src/views/footer/complex-footer.ts
+++ b/packages/server/src/views/footer/complex-footer.ts
@@ -44,7 +44,7 @@ export const ComplexFooter = ({
                             </h2>`}
                             <ul class="${cls.footerInnerLinkList}">
                                 ${children.map(
-                                    ({ url, content }) => html`
+                                    ({ url, content, attributes }) => html`
                                         <li>
                                             <a
                                                 href="${url}"
@@ -52,6 +52,14 @@ export const ComplexFooter = ({
                                                     "navds-link"
                                                 ]} ${cls.footerLink}"
                                                 data-lenkegruppe="${heading}"
+                                                ${attributes
+                                                    ? Object.entries(attributes)
+                                                          .map(
+                                                              ([key, value]) =>
+                                                                  `${key}="${value}"`,
+                                                          )
+                                                          .join(" ")
+                                                    : ""}
                                             >
                                                 ${content}
                                             </a>

--- a/packages/server/src/views/footer/complex-footer.ts
+++ b/packages/server/src/views/footer/complex-footer.ts
@@ -2,7 +2,7 @@ import aksel from "decorator-client/src/styles/aksel.module.css";
 import cls from "decorator-client/src/styles/complex-footer.module.css";
 import utils from "decorator-client/src/styles/utils.module.css";
 import { ArrowUpIcon } from "decorator-icons";
-import html from "decorator-shared/html";
+import html, { htmlAttributes } from "decorator-shared/html";
 import { LinkGroup } from "decorator-shared/types";
 import { NavLogo } from "decorator-shared/views/nav-logo";
 import i18n from "../../i18n";
@@ -53,12 +53,7 @@ export const ComplexFooter = ({
                                                 ]} ${cls.footerLink}"
                                                 data-lenkegruppe="${heading}"
                                                 ${attributes
-                                                    ? Object.entries(attributes)
-                                                          .map(
-                                                              ([key, value]) =>
-                                                                  `${key}="${value}"`,
-                                                          )
-                                                          .join(" ")
+                                                    ? htmlAttributes(attributes)
                                                     : ""}
                                             >
                                                 ${content}

--- a/packages/server/src/views/footer/simple-footer.ts
+++ b/packages/server/src/views/footer/simple-footer.ts
@@ -17,10 +17,17 @@ export const SimpleFooter = ({
         <div class="${cls.simpleFooterContent} ${utilCls.contentContainer}">
             <div class="${cls.footerLinkList}">
                 ${links.map(
-                    ({ url, content }) => html`
+                    ({ url, content, attributes }) => html`
                         <a
                             href="${url}"
                             class="${aksel["navds-link"]} ${cls.footerLink}"
+                            ${attributes
+                                ? Object.entries(attributes)
+                                      .map(
+                                          ([key, value]) => `${key}="${value}"`,
+                                      )
+                                      .join(" ")
+                                : ""}
                             >${content}</a
                         >
                     `,

--- a/packages/server/src/views/footer/simple-footer.ts
+++ b/packages/server/src/views/footer/simple-footer.ts
@@ -1,7 +1,7 @@
 import aksel from "decorator-client/src/styles/aksel.module.css";
 import cls from "decorator-client/src/styles/simple-footer.module.css";
 import utilCls from "decorator-client/src/styles/utils.module.css";
-import html from "decorator-shared/html";
+import html, { htmlAttributes } from "decorator-shared/html";
 import { Link } from "decorator-shared/types";
 import i18n from "../../i18n";
 import { ScreenshareButton } from "./screenshare-button";
@@ -21,13 +21,7 @@ export const SimpleFooter = ({
                         <a
                             href="${url}"
                             class="${aksel["navds-link"]} ${cls.footerLink}"
-                            ${attributes
-                                ? Object.entries(attributes)
-                                      .map(
-                                          ([key, value]) => `${key}="${value}"`,
-                                      )
-                                      .join(" ")
-                                : ""}
+                            ${attributes ? htmlAttributes(attributes) : ""}
                             >${content}</a
                         >
                     `,

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -5,6 +5,7 @@ export type Link = {
     content: string;
     url: string;
     path?: string;
+    attributes?: Record<string, string>;
 };
 
 export type LinkGroup = {


### PR DESCRIPTION
React 19 har strammet inn bruk av inline javascript href. Denne PR'en fikser knappen "Endre samtykke for informasjonskapsler" i bunn av dekoratøren:

- Legger til egen event listener for klikk som inneholder [data-consent-banner-trigger]-attributt
- Utvider mapping av lenker til å tillatte attributter i tillegg.