### PR TITLE
Tilbakestiller SEARCH_API_URL til riktig namespace

### DIFF
--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -17,7 +17,7 @@ env:
   - name: ENONICXP_SERVICES
     value: https://www-q6.nav.no/_/service
   - name: SEARCH_API_URL
-    value: https://navno-search-api.ekstern.dev.nav.no/content/decorator-search
+    value: http://navno-search-api.navno/content/decorator-search
   - name: XP_BASE_URL
     value: https://www-2.ansatt.dev.nav.no
   - name: LOGIN_URL

--- a/.nais/vars/dev-beta-tms.yml
+++ b/.nais/vars/dev-beta-tms.yml
@@ -17,7 +17,7 @@ env:
   - name: ENONICXP_SERVICES
     value: https://www-q6.nav.no/_/service
   - name: SEARCH_API_URL
-    value: https://navno-search-api.ekstern.dev.nav.no/content/decorator-search
+    value: http://navno-search-api.navno/content/decorator-search
   - name: XP_BASE_URL
     value: https://www.ansatt.dev.nav.no
   - name: LOGIN_URL

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -18,7 +18,7 @@ env:
   - name: ENONICXP_SERVICES
     value: https://www.dev.nav.no/_/service
   - name: SEARCH_API_URL
-    value: https://navno-search-api.ekstern.dev.nav.no/content/decorator-search
+    value: http://navno-search-api.navno/content/decorator-search
   - name: XP_BASE_URL
     value: https://www.ansatt.dev.nav.no
   - name: LOGIN_URL


### PR DESCRIPTION
Endrer SEARCH_API_URL slik at den kaller direkte mot app-navnet, men spesifiserer ".navno" pga kryssing av namespace. Dermed slipper vi å spesifisere ingress (forskjellig pr miljø). Dette er allerede gjort i prod, så endringen gjelder kun for dev, dev-beta og dev-beta-tms.