### PR TITLE
Legger inn 60 sekunders timeout på auth-kall

### DIFF
--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -96,7 +96,7 @@ const fetchAuthData = async (): Promise<AuthDataResponse> => {
                 console.error(`Failed to fetch auth data - ${error}`);
                 return { auth: { authenticated: false } };
             }),
-        5000,
+        1,
     );
 };
 

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -71,11 +71,12 @@ export function transformSessionToAuth(session: SessionData) {
 
 export const logout = () => (window.location.href = env("LOGOUT_URL"));
 
+const OneMinuteTimeout = 60000;
 const fetchAuthData = async (): Promise<AuthDataResponse> => {
     const url = endpointUrlWithParams("/auth");
     function fetchWithTimout<T>(
         promise: Promise<T>,
-        ms: number,
+        ms = OneMinuteTimeout,
         timeoutError = new Error("Fetch auth data timed out"),
     ): Promise<T> {
         const timeout = new Promise<never>((_, reject) => {
@@ -91,7 +92,6 @@ const fetchAuthData = async (): Promise<AuthDataResponse> => {
         fetch(url, {
             credentials: "include",
         }).then((res) => res.json() as Promise<AuthDataResponse>),
-        1,
     ).catch((error) => {
         console.error(`Failed to fetch auth data - ${error}`);
         return { auth: { authenticated: false } };

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -71,7 +71,7 @@ export function transformSessionToAuth(session: SessionData) {
 
 export const logout = () => (window.location.href = env("LOGOUT_URL"));
 
-const OneMinuteTimeout = 1;
+const OneMinuteTimeout = 60000;
 const fetchAuthData = async (): Promise<AuthDataResponse> => {
     const url = endpointUrlWithParams("/auth");
 

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -74,21 +74,17 @@ export const logout = () => (window.location.href = env("LOGOUT_URL"));
 const OneMinuteTimeout = 60000;
 const fetchAuthData = async (): Promise<AuthDataResponse> => {
     const url = endpointUrlWithParams("/auth");
-    function fetchWithTimout<T>(
-        promise: Promise<T>,
-        ms = OneMinuteTimeout,
-        timeoutError = new Error("Fetch auth data timed out"),
-    ): Promise<T> {
+    function fetchWithTimeout<T>(promise: Promise<T>): Promise<T> {
+        const timeoutError = new Error("Fetch auth data timed out");
         const timeout = new Promise<never>((_, reject) => {
             setTimeout(() => {
                 reject(timeoutError);
-            }, ms);
+            }, OneMinuteTimeout);
         });
-
-        // returns a race between timeout and the passed promise
         return Promise.race<T>([promise, timeout]);
     }
-    return fetchWithTimout(
+
+    return fetchWithTimeout(
         fetch(url, {
             credentials: "include",
         }).then((res) => res.json() as Promise<AuthDataResponse>),

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -90,14 +90,12 @@ const fetchAuthData = async (): Promise<AuthDataResponse> => {
     return fetchWithTimout(
         fetch(url, {
             credentials: "include",
-        })
-            .then((res) => res.json() as Promise<AuthDataResponse>)
-            .catch((error) => {
-                console.error(`Failed to fetch auth data - ${error}`);
-                return { auth: { authenticated: false } };
-            }),
+        }).then((res) => res.json() as Promise<AuthDataResponse>),
         1,
-    );
+    ).catch((error) => {
+        console.error(`Failed to fetch auth data - ${error}`);
+        return { auth: { authenticated: false } };
+    });
 };
 
 export const refreshAuthData = () =>


### PR DESCRIPTION
Sikrer at ikke Logg-inn knappen blir stående å spinne ved feil mot ID-porten

Testet i dev2 ved å sette timeout til 1 ms