### PR TITLE
Fikser header profilnavn alignment i Safari

### DIFF
--- a/packages/client/src/styles/header-button.module.css
+++ b/packages/client/src/styles/header-button.module.css
@@ -5,3 +5,9 @@
         padding: var(--a-spacing-2) var(--a-spacing-3);
     }
 }
+
+/* Fikser alignment i Safari når det er satt ellipsis på child-elementet */
+.headerButton :global(.label) {
+    display: inline-flex;
+    align-items: center;
+}

--- a/packages/server/src/views/components/button.ts
+++ b/packages/server/src/views/components/button.ts
@@ -42,6 +42,6 @@ export const Button = ({
             icon &&
             html`<span class="${cls["navds-button__icon"]}">${icon}</span>`
         }
-        <span class="${cls["navds-label"]}">${content}</span>
+        <span class="${clsx(cls["navds-label"], "label")}">${content}</span>
     </${href ? "a" : "button"}>
 `;


### PR DESCRIPTION
Fikser alignment i Safari når det er satt ellipsis på child-elementet. Feilen gjelder kun profilnavn når man er logget inn.