### PR TITLE
Begrense høyden på dropdown

### DIFF
--- a/packages/client/src/styles/dropdown-menu.module.css
+++ b/packages/client/src/styles/dropdown-menu.module.css
@@ -35,5 +35,8 @@
 
     @media (min-width: 768px) {
         height: initial;
+        max-height: 80dvh;
+        border-radius: 0 0 var(--a-border-radius-medium)
+            var(--a-border-radius-medium);
     }
 }

--- a/packages/client/src/styles/dropdown-menu.module.css
+++ b/packages/client/src/styles/dropdown-menu.module.css
@@ -35,5 +35,8 @@
 
     @media (min-width: 768px) {
         height: initial;
+        max-height: 80vh;
+        border-radius: 0 0 var(--a-border-radius-medium)
+            var(--a-border-radius-medium);
     }
 }


### PR DESCRIPTION
Fikser problemet med at innhold i dropdown på lavere skjermer eller i lave nettleservinduer ikke kunne scrolles i.

<img width="1042" height="690" alt="image" src="https://github.com/user-attachments/assets/e21c51ea-c51c-4d82-b33a-08d08f4d5354" />

