### PR TITLE
Endre lenke bedrift til arbeidsgiver

### DIFF
--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -25,7 +25,7 @@ export const makeContextLinks = (language: Language): ContextLink[] =>
               {
                   url: isDevMode
                       ? "?context=samarbeidspartner"
-                      : `${env.XP_BASE_URL}/no/samarbeidspartner`,
+                      : `${env.XP_BASE_URL}/samarbeidspartner`,
                   context: "samarbeidspartner",
               },
           ]

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -19,7 +19,7 @@ export const makeContextLinks = (language: Language): ContextLink[] =>
               {
                   url: isDevMode
                       ? "?context=arbeidsgiver"
-                      : `${env.XP_BASE_URL}/no/arbeidsgiver`,
+                      : `${env.XP_BASE_URL}/arbeidsgiver`,
                   context: "arbeidsgiver",
               },
               {

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -19,7 +19,7 @@ export const makeContextLinks = (language: Language): ContextLink[] =>
               {
                   url: isDevMode
                       ? "?context=arbeidsgiver"
-                      : `${env.XP_BASE_URL}/no/bedrift`,
+                      : `${env.XP_BASE_URL}/no/arbeidsgiver`,
                   context: "arbeidsgiver",
               },
               {

--- a/packages/server/src/menu/main-menu-mock.json
+++ b/packages/server/src/menu/main-menu-mock.json
@@ -190,7 +190,7 @@
                             },
                             {
                                 "displayName": "Arbeidsgiver",
-                                "path": "/no/bedrift",
+                                "path": "/arbeidsgiver",
                                 "id": "b9fb1110-22c1-44a5-81a5-74336d82ccb7",
                                 "hasChildren": true,
                                 "children": [

--- a/packages/server/src/menu/main-menu.ts
+++ b/packages/server/src/menu/main-menu.ts
@@ -76,11 +76,11 @@ export const mainMenuContextLinks = ({
                 },
                 {
                     content: "Arbeidsgiver",
-                    url: `${env.XP_BASE_URL}/no/bedrift`,
+                    url: `${env.XP_BASE_URL}/arbeidsgiver`,
                 },
                 {
                     content: "Samarbeidspartner",
-                    url: `${env.XP_BASE_URL}/no/samarbeidspartner`,
+                    url: `${env.XP_BASE_URL}/samarbeidspartner`,
                 },
             ];
         case "arbeidsgiver":
@@ -101,7 +101,7 @@ export const mainMenuContextLinks = ({
                     content: "Samarbeidspartner",
                     description:
                         "Helsepersonell, tiltaksarrangører, fylker og kommuner",
-                    url: `${env.XP_BASE_URL}/no/samarbeidspartner`,
+                    url: `${env.XP_BASE_URL}/samarbeidspartner`,
                 },
             ];
         case "samarbeidspartner":
@@ -112,7 +112,7 @@ export const mainMenuContextLinks = ({
                 },
                 {
                     content: "Arbeidsgiver",
-                    url: `${env.XP_BASE_URL}/no/bedrift`,
+                    url: `${env.XP_BASE_URL}/arbeidsgiver`,
                 },
             ];
     }

--- a/packages/server/src/views/header/main-menu.stories.ts
+++ b/packages/server/src/views/header/main-menu.stories.ts
@@ -242,7 +242,7 @@ const nbArbeidsgiverContextLinks = [
     {
         content: "Samarbeidspartner",
         description: "Helsepersonell, tiltaksarrangører, fylker og kommuner",
-        url: "https://www.ansatt.dev.nav.no/no/samarbeidspartner",
+        url: "https://www.ansatt.dev.nav.no/samarbeidspartner",
     },
 ];
 
@@ -298,10 +298,10 @@ const nbPrivatpersonContextLinks = [
     { content: "Min side", url: "https://www.ansatt.dev.nav.no/minside" },
     {
         content: "Arbeidsgiver",
-        url: "https://www.ansatt.dev.nav.no/no/bedrift",
+        url: "https://www.ansatt.dev.nav.no/arbeidsgiver",
     },
     {
         content: "Samarbeidspartner",
-        url: "https://www.ansatt.dev.nav.no/no/samarbeidspartner",
+        url: "https://www.ansatt.dev.nav.no/samarbeidspartner",
     },
 ];

--- a/packages/shared/test/urls.test.ts
+++ b/packages/shared/test/urls.test.ts
@@ -11,12 +11,12 @@ test("Frontpage URLs", () => {
     ).toBe("https://www.nav.no/");
     expect(
         makeFrontpageUrl({ language: "nb", context: "arbeidsgiver", baseUrl }),
-    ).toBe("https://www.nav.no/no/bedrift");
+    ).toBe("https://www.nav.no/arbeidsgiver");
     expect(
         makeFrontpageUrl({
             language: "nb",
             context: "samarbeidspartner",
             baseUrl,
         }),
-    ).toBe("https://www.nav.no/no/samarbeidspartner");
+    ).toBe("https://www.nav.no/samarbeidspartner");
 });

--- a/packages/shared/urls.ts
+++ b/packages/shared/urls.ts
@@ -15,9 +15,9 @@ export function makeFrontpageUrl({
         case "privatperson":
             return `${baseUrl}/`;
         case "arbeidsgiver":
-            return `${baseUrl}/no/bedrift`;
+            return `${baseUrl}/arbeidsgiver`;
         case "samarbeidspartner":
-            return `${baseUrl}/no/samarbeidspartner`;
+            return `${baseUrl}/samarbeidspartner`;
     }
 }
 


### PR DESCRIPTION
- Endrer lenker som redirectes fra /bedrift til å lenke direkte

- Fjerner også /no prefix på lenker til samarbeidspartner

- Testet i beta/dev2