### PR TITLE
Undertrykk console-feilmeldinger ved session-håndtering

### DIFF
--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -29,7 +29,10 @@ export async function fetchSession() {
         const sessionResponse = await fetch(sessionUrl, {
             credentials: "include",
         });
-
+        if (sessionResponse.status === 401) {
+            // Uinnlogget, ikke prøv å hente ut json
+            return null;
+        }
         return (await sessionResponse.json()) as SessionData;
     } catch (error) {
         console.error(`Failed to fetch session - ${error}`);
@@ -44,7 +47,10 @@ export async function fetchRenew() {
         const sessionResponse = await fetch(sessionRefreshUrl, {
             credentials: "include",
         });
-
+        if (sessionResponse.status === 401) {
+            // Uinnlogget, ikke prøv å hente ut json
+            return null;
+        }
         return (await sessionResponse.json()) as SessionData;
     } catch (error) {
         console.error(`Failed to renew session - ${error}`);

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -31,8 +31,7 @@ export async function fetchOrRenewSession(fetchOrRenew: FetchRenew) {
         const sessionResponse = await fetch(fetchUrl, {
             credentials: "include",
         });
-        if (sessionResponse.status === 401) {
-            // Uinnlogget, ikke prøv å hente ut json
+        if (!sessionResponse.ok) {
             return null;
         }
         return (await sessionResponse.json()) as SessionData;

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -22,11 +22,12 @@ export type SessionData = {
     };
 };
 
-export async function fetchSession() {
+export async function fetchOrRenewSession(renew: boolean) {
     const sessionUrl = window.__DECORATOR_DATA__.env.LOGIN_SESSION_API_URL;
+    const fetchUrl = `${sessionUrl}${renew ?? "/refresh"}`;
 
     try {
-        const sessionResponse = await fetch(sessionUrl, {
+        const sessionResponse = await fetch(fetchUrl, {
             credentials: "include",
         });
         if (sessionResponse.status === 401) {
@@ -35,25 +36,9 @@ export async function fetchSession() {
         }
         return (await sessionResponse.json()) as SessionData;
     } catch (error) {
-        console.error(`Failed to fetch session - ${error}`);
-        return null;
-    }
-}
-
-export async function fetchRenew() {
-    const sessionRefreshUrl = `${window.__DECORATOR_DATA__.env.LOGIN_SESSION_API_URL}/refresh`;
-
-    try {
-        const sessionResponse = await fetch(sessionRefreshUrl, {
-            credentials: "include",
-        });
-        if (sessionResponse.status === 401) {
-            // Uinnlogget, ikke prøv å hente ut json
-            return null;
-        }
-        return (await sessionResponse.json()) as SessionData;
-    } catch (error) {
-        console.error(`Failed to renew session - ${error}`);
+        console.error(
+            `Failed to ${renew ? "renew" : "fetch"} session - ${error}`,
+        );
         return null;
     }
 }

--- a/packages/client/src/helpers/auth.ts
+++ b/packages/client/src/helpers/auth.ts
@@ -22,9 +22,10 @@ export type SessionData = {
     };
 };
 
-export async function fetchOrRenewSession(renew: boolean) {
+export type FetchRenew = "fetch" | "renew";
+export async function fetchOrRenewSession(fetchOrRenew: FetchRenew) {
     const sessionUrl = window.__DECORATOR_DATA__.env.LOGIN_SESSION_API_URL;
-    const fetchUrl = `${sessionUrl}${renew ?? "/refresh"}`;
+    const fetchUrl = `${sessionUrl}${fetchOrRenew === "renew" ? "/refresh" : ""}`;
 
     try {
         const sessionResponse = await fetch(fetchUrl, {
@@ -36,9 +37,7 @@ export async function fetchOrRenewSession(renew: boolean) {
         }
         return (await sessionResponse.json()) as SessionData;
     } catch (error) {
-        console.error(
-            `Failed to ${renew ? "renew" : "fetch"} session - ${error}`,
-        );
+        console.error(`Failed to ${fetchOrRenew} session - ${error}`);
         return null;
     }
 }

--- a/packages/client/src/views/logout-warning/logout-warning.ts
+++ b/packages/client/src/views/logout-warning/logout-warning.ts
@@ -1,7 +1,6 @@
 import {
     SessionData,
-    fetchRenew,
-    fetchSession,
+    fetchOrRenewSession,
     transformSessionToAuth,
 } from "../../helpers/auth";
 import { addSecondsFromNow } from "../../helpers/time";
@@ -16,7 +15,7 @@ class LogoutWarning extends HTMLElement {
 
     private onVisibilityChange = async () => {
         if (param("logoutWarning") && document.visibilityState === "visible") {
-            this.updateDialogs(await fetchSession());
+            this.updateDialogs(await fetchOrRenewSession(false));
         }
     };
 
@@ -33,7 +32,7 @@ class LogoutWarning extends HTMLElement {
     };
 
     private init = async () => {
-        this.updateDialogs(await fetchSession());
+        this.updateDialogs(await fetchOrRenewSession(false));
 
         window.loginDebug = {
             expireToken: (seconds: number) => {
@@ -63,7 +62,7 @@ class LogoutWarning extends HTMLElement {
         this.sessionDialog = this.querySelector("session-dialog")!;
         this.tokenDialog = this.querySelector("token-dialog")!;
         this.tokenDialog.addEventListener("renew", async () =>
-            this.updateDialogs(await fetchRenew()),
+            this.updateDialogs(await fetchOrRenewSession(true)),
         );
     }
 

--- a/packages/client/src/views/logout-warning/logout-warning.ts
+++ b/packages/client/src/views/logout-warning/logout-warning.ts
@@ -15,7 +15,7 @@ class LogoutWarning extends HTMLElement {
 
     private onVisibilityChange = async () => {
         if (param("logoutWarning") && document.visibilityState === "visible") {
-            this.updateDialogs(await fetchOrRenewSession(false));
+            this.updateDialogs(await fetchOrRenewSession("fetch"));
         }
     };
 
@@ -32,7 +32,7 @@ class LogoutWarning extends HTMLElement {
     };
 
     private init = async () => {
-        this.updateDialogs(await fetchOrRenewSession(false));
+        this.updateDialogs(await fetchOrRenewSession("fetch"));
 
         window.loginDebug = {
             expireToken: (seconds: number) => {
@@ -62,7 +62,7 @@ class LogoutWarning extends HTMLElement {
         this.sessionDialog = this.querySelector("session-dialog")!;
         this.tokenDialog = this.querySelector("token-dialog")!;
         this.tokenDialog.addEventListener("renew", async () =>
-            this.updateDialogs(await fetchOrRenewSession(true)),
+            this.updateDialogs(await fetchOrRenewSession("renew")),
         );
     }
 


### PR DESCRIPTION
#639 

Avbryter uthenting av JSON ved feil for unngå at console-error spammer error-loggene til apper som bruker dekoratøren.

PR-en slår også sammen fetch og renew til en funksjon da de overlapper svært mye.

Testet i dev i to døgn. Ser ut til å gi ønsket effekt. Ingen har rapportert problemer.