### PR TITLE
Endrer sjekk av om dekoratøren kjøres i prod eller ikke

### DIFF
--- a/packages/client/src/analytics/amplitude.ts
+++ b/packages/client/src/analytics/amplitude.ts
@@ -1,3 +1,4 @@
+import { isProd } from "../helpers/env";
 import {
     buildLocationString,
     getCurrentReferrer,
@@ -42,7 +43,7 @@ export const mockAmplitude = () => {
 };
 
 export const initAmplitude = async () => {
-    if (process.env.ENV !== "prod") {
+    if (!isProd()) {
         console.log(amplitudeDeprecated);
         return Promise.resolve(amplitudeDeprecated);
     } else {


### PR DESCRIPTION
Sjekker hostname istedet for ENV for å sjekke om dekoratøren kjøres i en app som kjøres i prod.