### PR TITLE
Endrer sjekk av miljø i logAmplitudeEvent også

### DIFF
--- a/packages/client/src/analytics/amplitude.ts
+++ b/packages/client/src/analytics/amplitude.ts
@@ -171,7 +171,7 @@ export const logAmplitudeEvent = async (
     eventData: EventData = {},
     origin = "nav-dekoratoren",
 ) => {
-    if (process.env.ENV !== "prod") {
+    if (!isProd()) {
         console.log(amplitudeDeprecated);
         return Promise.resolve(amplitudeDeprecated);
     } else {


### PR DESCRIPTION
Glemte selve logg-funksjon for Amplitude ved sjekk av miljø...
Nå sjekker begge funksjoner isProd korrekt.