### PR TITLE
Forbedrer måten endringer i ta-config oppdages

### DIFF
--- a/packages/server/src/lib/config-map-watcher.ts
+++ b/packages/server/src/lib/config-map-watcher.ts
@@ -88,9 +88,6 @@ export class ConfigMapWatcher<FileContent extends Record<string, unknown>> {
 
             this.pollTimeout = setTimeout(async () => {
                 try {
-                    console.log(
-                        `Polling check for updates on ${this.filePath}`,
-                    );
                     await this.checkForUpdate(onUpdate);
                 } catch (e) {
                     console.error(

--- a/packages/server/src/lib/config-map-watcher.ts
+++ b/packages/server/src/lib/config-map-watcher.ts
@@ -88,6 +88,9 @@ export class ConfigMapWatcher<FileContent extends Record<string, unknown>> {
 
             this.pollTimeout = setTimeout(async () => {
                 try {
+                    console.log(
+                        `Polling check for updates on ${this.filePath}`,
+                    );
                     await this.checkForUpdate(onUpdate);
                 } catch (e) {
                     console.error(

--- a/packages/server/src/task-analytics-config.ts
+++ b/packages/server/src/task-analytics-config.ts
@@ -36,6 +36,7 @@ const configMapWatcher = new ConfigMapWatcher<TaskAnalyticsSurvey>({
             config.surveys = validated;
         }
     },
+    shouldPoll: true,
 });
 
 const validateSurveys = (surveys: unknown) => {


### PR DESCRIPTION
Fikser problemer med lytting av ConfigMap.

- Lytter til endring i hele mappen og sjekker deretter den aktuelle filen.
- Legger til poll med 60 sekunders intervall som backup.
