### PR TITLE
Lagt til extraParams for alle tracking-events

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ https://github.com/navikt/nav-dekoratoren-moduler#getanalyticsinstance
 
 If the user has not given consent to tracking and analytics, Amplitude and Umami will not initiate. Instead a mock function will be returned. The mock function will take any logging and discard it before it's sent from the user, therefore the team doesn't have to handle any lack of consent especially unless they have spesific needs.
 
+#### 4.7.3 Custom analytics parameters
+
+You can add custom parameters to all analytics events by setting `window.__DECORATOR_DATA__.extraParams`. These parameters will be automatically included in all logged events.
+
 ### 4.8 Surveys using Task Analytics and Skyra 📋
 
 Task Analytics and Skyra are used to conduct surveys on nav.no. Dekoratøren will load the required scripts for both services, but only if the user has given consent to surveys. Task Analytics surveys are set up in a separate repository. Please see [nav-dekoratoren-config](https://github.com/navikt/nav-dekoratoren-config) or contact Team Nav.no for more information.

--- a/packages/client/src/analytics/amplitude.ts
+++ b/packages/client/src/analytics/amplitude.ts
@@ -184,6 +184,7 @@ export const logAmplitudeEvent = async (
         return amplitude.track(
             eventName,
             {
+                ...extraWindowParams(),
                 ...eventData,
                 // This field was set for use in the old amplitude-proxy
                 // In the current proxy version, source_name serves the same purpose
@@ -192,7 +193,6 @@ export const logAmplitudeEvent = async (
                 origin,
                 originVersion: eventData.originVersion || "unknown",
                 viaDekoratoren: true,
-                ...extraWindowParams(),
             },
             {
                 ingestion_metadata: {

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -21,11 +21,11 @@ export const logUmamiEvent = async (
                     ? (getCurrentReferrer() ?? props.referrer)
                     : undefined,
             data: {
+                ...extraWindowParams(),
                 ...eventData,
                 origin,
                 originVersion: eventData.originVersion || "unknown",
                 viaDekoratoren: true,
-                ...extraWindowParams(),
             },
         }));
     }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -60,6 +60,8 @@ export type AppState = {
     // and should be included in the server-HTML of consuming applications
     headAssets?: HtmlElementProps[];
     allowedStorage: PublicStorageItem[];
+    // Extra parameters that can be set by consuming applications for analytics
+    extraParams?: Record<string, unknown>;
 };
 
 export type MainMenuContextLink = {


### PR DESCRIPTION
Utvidet `window._DECORATOR_DATA_` med et nytt objekt: `extraParams`. Disse verdiene vil automatisk inkluderes i alle tracking-events.

Usikker på om vi trenger den ekstra sikkerheten i `getExtraParams()` da jeg tror vi injecter andre "usikre" elementer uansett.