### PR TITLE
Øker versjonsnummer for samtykkebanner til 2

### DIFF
--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -10,7 +10,7 @@ import { endpointUrlWithoutParams } from "./helpers/urls";
 const DECORATOR_DATA_TIMEOUT = 5000;
 
 export class WebStorageController {
-    currentConsentVersion: number = 1;
+    currentConsentVersion: number = 2;
     consentKey: string = "navno-consent";
 
     constructor() {


### PR DESCRIPTION
Vi har gjort endel endringer i cookie-erklæringen som gjør at alle må samtykke til eller avslå frivillig sporing på nytt. Denne PR'en øker versjonsnummeret slik at ny samtykkebanner blir trigget hos alle som besøker nav.no.