### PR TITLE
Sletter lagret samtykkeobjekt når bruker klikker 'endre samtykke'

### DIFF
--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -98,6 +98,10 @@ export class WebStorageController {
         }, 1000);
     };
 
+    private resetConsentHandler = () => {
+        Cookies.remove(this.consentKey, { domain: this.getConsentDomain() });
+    };
+
     private pingConsentBack = (consent: Consent) => {
         const pingBody = {
             consentObject: consent,
@@ -258,6 +262,7 @@ export class WebStorageController {
      * ----------------------------------------------------------------------- */
 
     public showConsentBanner = () => {
+        this.resetConsentHandler();
         window.dispatchEvent(createEvent("showConsentBanner", {}));
     };
 


### PR DESCRIPTION
Dersom man klikker på "endre samtykke for informasjonskapsler" og deretter klikker lenken til cookie-erklæringen så lukkes samtykkevinduet. Det skjer kun dersom man har gitt samtykke tidligere.

For nye brukere vises modalen som den skal.

Foreslår å bare slette hele cookien og begynne på "ny frisk" fordi brukeren uansett vil måtte ta et aktivt ja/nei-valg når samtykkevinduet vises.