### PR TITLE
Tillate lagringsnøkkel for flexjar

### DIFF
--- a/packages/server/src/decorator-data.ts
+++ b/packages/server/src/decorator-data.ts
@@ -445,6 +445,14 @@ const storageDictionary: Set<AllowedStorageItem> = new Set([
         description: "Sporer unike sidevisninger i Experiences",
         optional: false,
     },
+    {
+        name: "flexjar-*",
+        type: ["localstorage"],
+        service: "Team eSYFO",
+        description:
+            "Brukes av verktøyet Flexjar for å huske om du har besvart en spørreundersøkelse eller valgt å ikke svare.",
+        optional: true,
+    },
 ]);
 
 const buildAllowedStorage = () => {


### PR DESCRIPTION
Tillater å lagre data lokalt med nøkkel `flexjar-*`. Oppdatering av cookieerklæring og bump av samtykkeversjon blir også gjort.