### PR TITLE
Bumper samtykkebanner til versjon 3 for å cleare alle samtykker

### DIFF
--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -9,6 +9,14 @@ import { endpointUrlWithoutParams } from "./helpers/urls";
 
 const DECORATOR_DATA_TIMEOUT = 5000;
 
+// Changelog consent versioning
+// --------------------------------
+// (Remember to update this list when making changes that require re-consent)
+
+// V3: 03.11.2025: Added storage key 'flexjar-*' as well as updates to cookie declaration
+// V2: 22.10.2025: Updates in the cookie declaration on how Umami works.
+// V1: 28.02.2025: Initial version
+
 export class WebStorageController {
     currentConsentVersion: number = 3;
     consentKey: string = "navno-consent";

--- a/packages/client/src/webStorage.ts
+++ b/packages/client/src/webStorage.ts
@@ -10,7 +10,7 @@ import { endpointUrlWithoutParams } from "./helpers/urls";
 const DECORATOR_DATA_TIMEOUT = 5000;
 
 export class WebStorageController {
-    currentConsentVersion: number = 2;
+    currentConsentVersion: number = 3;
     consentKey: string = "navno-consent";
 
     constructor() {


### PR DESCRIPTION
Vi legger til ny bruk og lagring av flexjar-key, så vi må oppdatere cookieerklæringen og resette samtykke for samtlige.

Introduserer også nytt regime for å holde kontroll på hvorfor vi bumpet samtykkeversjon og når.