### PR TITLE
Legger til mocket dekoratorenAnalytics. Blir overskrevet hvis samtykke

### DIFF
--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -16,6 +16,10 @@ declare global {
 
 const logPageViewCallback = (auth: Auth) => () => logPageView(auth);
 
+export const mockAnalytics = () => {
+    return Promise.resolve();
+};
+
 export const initAnalytics = (auth: Auth) => {
     initMockAmplitude(); // Some teams are calling window.dekoratorenAmplitude directly
     initTaskAnalyticsScript();

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,6 +1,10 @@
 /// <reference types="./client.d.ts" />
 import "vite/modulepreload-polyfill";
-import { initAnalytics, stopAnalytics } from "./analytics/analytics";
+import {
+    initAnalytics,
+    mockAnalytics,
+    stopAnalytics,
+} from "./analytics/analytics";
 import { initHistoryEvents, initScrollToEvents } from "./events";
 import { addFaroMetaData } from "./faro";
 import { refreshAuthData } from "./helpers/auth";
@@ -71,6 +75,7 @@ const init = () => {
     window.dekoratorenIsReady = () => true;
     // Need mocked amplitude to avoid breaking changes in consuming applications
     window.dekoratorenAmplitude = mockAmplitude;
+    window.dekoratorenAnalytics = mockAnalytics;
 
     const { consent } = window.webStorageController.getCurrentConsent();
     if (consent?.analytics) {


### PR DESCRIPTION
Tidligere dekoratorenAmplitude ble mocket med en resolved promise ved oppstart. Dersom bruker ga samtykke ble window.dekoratorenAmplitude overskrevet av den ekte funksjonen - hvis ikke ble eventuelle kall til window.dekoratorenAmplitude returnert i stillhet med resolved promise.

Fordi team har blitt vant til denne måten å kalle analysefunksjon direkte, foreslår vi at vi gjør det samme med window.dekoratorenAnalytics slik at overgangen til teamene blir enklere. Da slipper de å sjekke om funksjonen finnes og logging-forsøk uten brukersamtykke vil bare bli forkastet i stillhet uten å forlate brukerens klient.