### PR TITLE
Mer robust styling for modal

### DIFF
--- a/packages/client/src/styles/modal.module.css
+++ b/packages/client/src/styles/modal.module.css
@@ -4,6 +4,7 @@
     border-radius: var(--a-border-radius-large);
     padding: var(--a-spacing-10);
     box-shadow: var(--a-shadow-xlarge);
+    margin: auto;
 }
 
 .modal::backdrop {


### PR DESCRIPTION
Setter `margin:auto` på `.modal` (dialog-elementet). Tidligere brukte vi stylingen som er standard i nettleser, men den overstyres veldig lett. F.eks. med `* { margin:0 }`.

Plasseringen og stylingen er den samme som tidligere, men med høyere spesifisitet.