### PR TITLE
Vaske UUID fra Umami-objektet

### DIFF
--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -6,6 +6,31 @@ import {
 } from "./analytics";
 import { AnalyticsEventArgs, EventData } from "./types";
 
+const UUID_REGEX =
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+export const redactUuids = (value: any): any => {
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    if (typeof value === "string") {
+        return value.replace(UUID_REGEX, "[redacted]");
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(redactUuids);
+    }
+
+    if (typeof value === "object") {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, val]) => [key, redactUuids(val)]),
+        );
+    }
+
+    return value;
+};
+
 export const logUmamiEvent = async (
     eventName: string,
     eventData: EventData = {},
@@ -15,18 +40,21 @@ export const logUmamiEvent = async (
         window.__DECORATOR_DATA__.features["dekoratoren.umami"] &&
         typeof umami !== "undefined"
     ) {
+        const url = buildLocationString({
+            includeOrigin: false,
+            includeHash: false,
+        });
+
         return umami.track((props) => ({
             ...props,
             name: eventName === "besøk" ? undefined : eventName,
-            url: buildLocationString({
-                includeOrigin: false,
-                includeHash: false,
-            }),
-            title: window.document.title,
-            referrer:
+            url: redactUuids(url),
+            title: redactUuids(window.document.title),
+            referrer: redactUuids(
                 eventName === "besøk"
                     ? (getCurrentReferrer() ?? props.referrer)
                     : undefined,
+            ),
             data: {
                 ...eventData,
                 origin,

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -16,7 +16,7 @@ export const redactUuids = (value: any): any => {
     }
 
     if (typeof value === "string") {
-        return value.replace(UUID_REGEX, "[redacted]");
+        return value.replace(UUID_REGEX, "[redacted: uuid]");
     }
 
     if (Array.isArray(value)) {
@@ -99,7 +99,7 @@ export const createUmamiEvent = (props: AnalyticsEventArgs) => {
         målgruppe: context,
         innholdstype: pageType,
         tema: pageTheme,
-        søkeord: eventName === "søk" ? "[redacted]" : undefined,
+        søkeord: eventName === "søk" ? "[redacted: search]" : undefined,
         ...rest,
     });
 };

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -7,7 +7,7 @@ import {
 import { AnalyticsEventArgs, EventData } from "./types";
 
 const UUID_REGEX =
-    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
 const EXEMPT_KEYS = ["website"];
 
 export const redactUuids = (value: any): any => {
@@ -16,7 +16,7 @@ export const redactUuids = (value: any): any => {
     }
 
     if (typeof value === "string") {
-        return value.replace(UUID_REGEX, "[redacted: uuid]");
+        return value.replaceAll(UUID_REGEX, "[redacted: uuid]");
     }
 
     if (Array.isArray(value)) {

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -7,7 +7,7 @@ import {
 import { AnalyticsEventArgs, EventData } from "./types";
 
 const UUID_REGEX =
-    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
 const EXEMPT_KEYS = ["website"];
 
 export const redactUuids = (value: any): any => {

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -37,6 +37,15 @@ export const redactUuids = (value: any): any => {
     return value;
 };
 
+export const redactReferrerQueryString = (referrer: string): string => {
+    if (!referrer) return referrer;
+    if (!referrer.includes("?")) return referrer;
+
+    const [baseUrl] = referrer.split("?");
+
+    return baseUrl;
+};
+
 export const logUmamiEvent = async (
     eventName: string,
     eventData: EventData = {},
@@ -59,7 +68,9 @@ export const logUmamiEvent = async (
                 title: window.document.title,
                 referrer:
                     eventName === "besøk"
-                        ? (getCurrentReferrer() ?? props.referrer)
+                        ? redactReferrerQueryString(
+                              getCurrentReferrer() ?? props.referrer,
+                          )
                         : undefined,
                 data: {
                     ...eventData,

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -45,24 +45,25 @@ export const logUmamiEvent = async (
             includeHash: false,
         });
 
-        return umami.track((props) => ({
-            ...props,
-            name: eventName === "besøk" ? undefined : eventName,
-            url: redactUuids(url),
-            title: redactUuids(window.document.title),
-            referrer: redactUuids(
-                eventName === "besøk"
-                    ? (getCurrentReferrer() ?? props.referrer)
-                    : undefined,
-            ),
-            data: {
-                ...eventData,
-                origin,
-                originVersion: eventData.originVersion || "unknown",
-                viaDekoratoren: true,
-                ...extraWindowParams(),
-            },
-        }));
+        return umami.track((props) =>
+            redactUuids({
+                ...props,
+                name: eventName === "besøk" ? undefined : eventName,
+                url,
+                title: window.document.title,
+                referrer:
+                    eventName === "besøk"
+                        ? (getCurrentReferrer() ?? props.referrer)
+                        : undefined,
+                data: {
+                    ...eventData,
+                    origin,
+                    originVersion: eventData.originVersion || "unknown",
+                    viaDekoratoren: true,
+                    ...extraWindowParams(),
+                },
+            }),
+        );
     }
 };
 

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -10,6 +10,8 @@ const UUID_REGEX =
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
 
 export const redactUuids = (value: any): any => {
+    const exemptKeys = ["website"];
+
     if (value === null || value === undefined) {
         return value;
     }
@@ -24,7 +26,12 @@ export const redactUuids = (value: any): any => {
 
     if (typeof value === "object") {
         return Object.fromEntries(
-            Object.entries(value).map(([key, val]) => [key, redactUuids(val)]),
+            Object.entries(value).map(([key, val]) => {
+                if (exemptKeys.includes(key)) {
+                    return [key, val];
+                }
+                return [key, redactUuids(val)];
+            }),
         );
     }
 

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -8,10 +8,9 @@ import { AnalyticsEventArgs, EventData } from "./types";
 
 const UUID_REGEX =
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const EXEMPT_KEYS = ["website"];
 
 export const redactUuids = (value: any): any => {
-    const exemptKeys = ["website"];
-
     if (value === null || value === undefined) {
         return value;
     }
@@ -27,7 +26,7 @@ export const redactUuids = (value: any): any => {
     if (typeof value === "object") {
         return Object.fromEntries(
             Object.entries(value).map(([key, val]) => {
-                if (exemptKeys.includes(key)) {
+                if (EXEMPT_KEYS.includes(key)) {
                     return [key, val];
                 }
                 return [key, redactUuids(val)];


### PR DESCRIPTION
- Går igjennom hele objektet som sendes til Umami og erstattet uuid med "[redacted]".
- Har mekanisme for å unnta enkelte nøkler (feks website)