### PR TITLE
Redacter '/users' fra url

### DIFF
--- a/packages/client/src/analytics/helpers/redactData.test.ts
+++ b/packages/client/src/analytics/helpers/redactData.test.ts
@@ -123,6 +123,53 @@ describe("redactData", () => {
         });
     });
 
+    describe("local path redaction", () => {
+        it("should redact URLs containing /users/ (lowercase)", () => {
+            expect(redactData("/users/john/documents/file.txt", "url")).toBe(
+                "[redacted: local path]",
+            );
+        });
+
+        it("should redact URLs containing /Users/ (uppercase)", () => {
+            expect(redactData("/Users/John/Documents/file.txt", "url")).toBe(
+                "[redacted: local path]",
+            );
+        });
+
+        it("should redact referrer containing local paths", () => {
+            expect(
+                redactData("file:///Users/dev/project/index.html", "referrer"),
+            ).toBe("[redacted: local path]");
+        });
+
+        it("should redact destinasjon containing local paths", () => {
+            expect(
+                redactData(
+                    "/users/someone/downloads/report.pdf",
+                    "destinasjon",
+                ),
+            ).toBe("[redacted: local path]");
+        });
+
+        it("should not redact local paths for non-URL keys", () => {
+            expect(redactData("/users/john/file.txt", "someOtherKey")).toBe(
+                "/users/john/file.txt",
+            );
+        });
+
+        it("should redact local paths in URL keys within objects", () => {
+            expect(
+                redactData({
+                    url: "/Users/dev/project/page.html",
+                    name: "test",
+                }),
+            ).toEqual({
+                url: "[redacted: local path]",
+                name: "test",
+            });
+        });
+    });
+
     describe("array values", () => {
         it("should recursively redact array items", () => {
             const uuid = "123e4567-e89b-12d3-a456-426614174000";

--- a/packages/client/src/analytics/helpers/redactData.test.ts
+++ b/packages/client/src/analytics/helpers/redactData.test.ts
@@ -227,6 +227,32 @@ describe("redactData", () => {
                 });
             });
         });
+
+        describe("should NOT redact legitimate web URLs", () => {
+            it("should not redact /api/users/ paths", () => {
+                expect(redactData("/api/users/123", "url")).toBe(
+                    "/api/users/123",
+                );
+            });
+
+            it("should not redact /api/home/ paths", () => {
+                expect(redactData("/settings/home/dashboard", "url")).toBe(
+                    "/settings/home/dashboard",
+                );
+            });
+
+            it("should not redact full URLs with /users/ in path", () => {
+                expect(
+                    redactData("https://api.example.com/api/users/123", "url"),
+                ).toBe("https://api.example.com/api/users/123");
+            });
+
+            it("should not redact full URLs with /home/ in path", () => {
+                expect(
+                    redactData("https://example.com/home/dashboard", "url"),
+                ).toBe("https://example.com/home/dashboard");
+            });
+        });
     });
 
     describe("array values", () => {

--- a/packages/client/src/analytics/helpers/redactData.ts
+++ b/packages/client/src/analytics/helpers/redactData.ts
@@ -6,8 +6,10 @@ const UUID_REGEX =
 // Detects local file system paths:
 // - Windows: C:\Users\..., C:/Users/..., file:///C:/...
 // - Unix/macOS: /Users/..., /home/..., file:///home/...
+// Note: Only matches /users/ or /home/ at the START of the path to avoid
+// false positives on legitimate URLs like /api/users/123
 const LOCAL_PATH_REGEX = new RegExp(
-    String.raw`(?:^file:\/\/\/|^[a-z]:[\/\\]|(?:^|[\/\\])(?:users|home)[\/\\])`,
+    String.raw`(?:^file:\/\/\/|^[a-z]:[\/\\]|^[\/\\]?(?:users|home)[\/\\])`,
     "i",
 );
 

--- a/packages/client/src/analytics/helpers/redactData.ts
+++ b/packages/client/src/analytics/helpers/redactData.ts
@@ -2,13 +2,20 @@ import { redactFromUrl } from "./redactUrl";
 
 const UUID_REGEX =
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const LOCAL_PATH_REGEX = /\/users\//i;
 const EXEMPT_KEYS = new Set(["website"]);
 const URL_KEYS = new Set(["url", "referrer", "destinasjon"]);
 
 const redactString = (value: string, key?: string): string => {
-    const redactResult =
+    let result =
         key && URL_KEYS.has(key) ? redactFromUrl(value).redactedUrl : value;
-    return redactResult.replaceAll(UUID_REGEX, "[redacted: uuid]");
+
+    // Redact URLs containing local file paths (e.g., /users/ or /Users/)
+    if (key && URL_KEYS.has(key) && LOCAL_PATH_REGEX.test(result)) {
+        result = "[redacted: local path]";
+    }
+
+    return result.replaceAll(UUID_REGEX, "[redacted: uuid]");
 };
 
 const redactObject = (

--- a/packages/client/src/analytics/helpers/redactData.ts
+++ b/packages/client/src/analytics/helpers/redactData.ts
@@ -6,8 +6,10 @@ const UUID_REGEX =
 // Detects local file system paths:
 // - Windows: C:\Users\..., C:/Users/..., file:///C:/...
 // - Unix/macOS: /Users/..., /home/..., file:///home/...
-const LOCAL_PATH_REGEX =
-    /(?:^file:\/\/\/|^[a-z]:[\\/]|(?:^|[\\/])(?:users|home)[\\/])/i;
+const LOCAL_PATH_REGEX = new RegExp(
+    String.raw`(?:^file:\/\/\/|^[a-z]:[\/\\]|(?:^|[\/\\])(?:users|home)[\/\\])`,
+    "i",
+);
 
 const EXEMPT_KEYS = new Set(["website"]);
 const URL_KEYS = new Set(["url", "referrer", "destinasjon"]);

--- a/packages/client/src/analytics/helpers/redactData.ts
+++ b/packages/client/src/analytics/helpers/redactData.ts
@@ -2,18 +2,24 @@ import { redactFromUrl } from "./redactUrl";
 
 const UUID_REGEX =
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
-const LOCAL_PATH_REGEX = /\/users\//i;
+
+// Detects local file system paths:
+// - Windows: C:\Users\..., C:/Users/..., file:///C:/...
+// - Unix/macOS: /Users/..., /home/..., file:///home/...
+const LOCAL_PATH_REGEX =
+    /(?:^file:\/\/\/|^[a-z]:[\\/]|(?:^|[\\/])(?:users|home)[\\/])/i;
+
 const EXEMPT_KEYS = new Set(["website"]);
 const URL_KEYS = new Set(["url", "referrer", "destinasjon"]);
 
 const redactString = (value: string, key?: string): string => {
-    let result =
-        key && URL_KEYS.has(key) ? redactFromUrl(value).redactedUrl : value;
-
     // Redact URLs containing local file paths (e.g., /users/ or /Users/)
-    if (key && URL_KEYS.has(key) && LOCAL_PATH_REGEX.test(result)) {
-        result = "[redacted: local path]";
+    if (key && URL_KEYS.has(key) && LOCAL_PATH_REGEX.test(value)) {
+        return "[redacted: local path]";
     }
+
+    const result =
+        key && URL_KEYS.has(key) ? redactFromUrl(value).redactedUrl : value;
 
     return result.replaceAll(UUID_REGEX, "[redacted: uuid]");
 };


### PR DESCRIPTION
Når brukere laster opp filer blir hele den lokale stien rapportert inn i url i enkelte applikasjoner. Dette må redactes, så vi søker på "/users" og fjerner disse.