### PR TITLE
Treffer på local path som er prefixet med '/'

### DIFF
--- a/packages/client/src/analytics/helpers/redactData.test.ts
+++ b/packages/client/src/analytics/helpers/redactData.test.ts
@@ -195,6 +195,15 @@ describe("redactData", () => {
                     "[redacted: local path]",
                 );
             });
+
+            it("should redact Windows path with leading slash", () => {
+                expect(
+                    redactData(
+                        "/C:/Users/Users Name/Desktop/soknader Ortoser.htm",
+                        "url",
+                    ),
+                ).toBe("[redacted: local path]");
+            });
         });
 
         describe("URL key handling", () => {

--- a/packages/client/src/analytics/helpers/redactData.ts
+++ b/packages/client/src/analytics/helpers/redactData.ts
@@ -4,12 +4,12 @@ const UUID_REGEX =
     /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
 
 // Detects local file system paths:
-// - Windows: C:\Users\..., C:/Users/..., file:///C:/...
+// - Windows: C:\Users\..., C:/Users/..., /C:/Users/..., file:///C:/...
 // - Unix/macOS: /Users/..., /home/..., file:///home/...
 // Note: Only matches /users/ or /home/ at the START of the path to avoid
 // false positives on legitimate URLs like /api/users/123
 const LOCAL_PATH_REGEX = new RegExp(
-    String.raw`(?:^file:\/\/\/|^[a-z]:[\/\\]|^[\/\\]?(?:users|home)[\/\\])`,
+    String.raw`(?:^file:\/\/\/|^[\/\\]?[a-z]:[\/\\]|^[\/\\]?(?:users|home)[\/\\])`,
     "i",
 );
 


### PR DESCRIPTION
I Umami er enkelte local paths logget med begynnende '/', trolig fordi man forventet det når url'en ikke begynner med 'https'. Denne fiksen tar høyde for det ved søk etter local path.