### PR TITLE
Bruk type-import for Faro

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,6 +11,9 @@
         "test": "TZ=UTC vitest run",
         "test:watch": "TZ=UTC vitest watch"
     },
+    "dependenciesComments": {
+        "@grafana/faro-web-sdk": "Type-only import. Faro is initialized by xp-frontend, keep version in sync."
+    },
     "dependencies": {
         "@grafana/faro-web-sdk": "1.19.0",
         "@navikt/ds-css": "7.36.0",

--- a/packages/client/src/client.d.ts
+++ b/packages/client/src/client.d.ts
@@ -1,4 +1,4 @@
-import { Faro } from "@grafana/faro-web-sdk";
+import type { Faro } from "@grafana/faro-web-sdk";
 import { AppState } from "decorator-shared/types";
 import { CustomEvents, MessageEvents } from "./events";
 import { WebStorageController } from "./webStorage";


### PR DESCRIPTION
Bruk type-import for Faro siden det initialiseres av xp-frontend. Også lagt til kommentar i dependenciesComments.