### PR TITLE
Setter farge på hover-tekst ved ops-message for å unngå override

### DIFF
--- a/packages/client/src/styles/ops-messages.module.css
+++ b/packages/client/src/styles/ops-messages.module.css
@@ -33,6 +33,7 @@
 
 .opsMessage:hover {
     text-decoration: none;
+    color: var(--a-text-on-action);
 }
 
 .opsMessage:focus {


### PR DESCRIPTION
Setter farge på hover-tekst ved ops-message for å unngå override