### PR TITLE
Støtter flere hosts for absolutt url ved driftsmelding

### DIFF
--- a/packages/client/src/views/ops-messages.ts
+++ b/packages/client/src/views/ops-messages.ts
@@ -10,6 +10,30 @@ import { endpointUrlWithParams } from "../helpers/urls";
 import { defineCustomElement } from "./custom-elements";
 import { analyticsClickListener } from "../analytics/analytics";
 
+const availableHosts = [
+    "www.nav.no",
+    "www.ansatt.dev.nav.no",
+    "www-2.ansatt.dev.nav.no",
+];
+
+const checkAndCorrectHost = (url: string): string => {
+    if (!url) {
+        return url;
+    }
+
+    if (url.startsWith("/")) {
+        const currentHostIsAvailableHosts =
+            availableHosts.includes(window.location.host) ||
+            window.location.host.startsWith("localhost");
+        const host = currentHostIsAvailableHosts
+            ? window.location.host
+            : "www.nav.no";
+        return `https://${host}${url}`;
+    }
+
+    return url;
+};
+
 export const OpsMessagesTemplate = ({
     opsMessages,
 }: {
@@ -17,9 +41,7 @@ export const OpsMessagesTemplate = ({
 }) => html`
     <section class="${cls.opsMessagesContent} ${utils.contentContainer}">
         ${opsMessages.map(({ heading, url, type }) => {
-            const fullUrl = url.startsWith("http")
-                ? url
-                : `https://www.nav.no${url}`;
+            const fullUrl = checkAndCorrectHost(url);
             return html`
                 <a href="${fullUrl}" class="${cls.opsMessage}">
                     ${type === "prodstatus"


### PR DESCRIPTION
Forbedrer første løsning som var en hastefiks. Denne løsningen setter riktig host avhengig av hvilket miljø slik at lenken til driftsmeldinger også fungerer i dev-stable og beta.