### PR TITLE
Fikse manglende deploy previous

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -1,4 +1,5 @@
 name: Build and test
+description: Build the application, run tests, upload static files to Nav CDN, and build/push Docker image.
 
 inputs:
   READER_TOKEN:
@@ -119,7 +120,7 @@ runs:
       with:
         team: personbruker
         # only tag 'latest' when explicitly true
-        tag: ${{ inputs.TAG_LATEST == 'true' && 'latest' || '' }}
+        tag: ${{ inputs.TAG_LATEST && 'latest' || '' }}
         # add arm64 only when TAG_LATEST is true
-        platforms: linux/amd64${{ inputs.TAG_LATEST == 'true' && ',linux/arm64' || '' }}
+        platforms: linux/amd64${{ inputs.TAG_LATEST && ',linux/arm64' || '' }}
         image_suffix: ${{ inputs.IMAGE_SUFFIX }}

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -43,6 +43,13 @@ runs:
         echo "version_id=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
         echo "VERSION_ID=$GITHUB_SHA" >> "$GITHUB_ENV"
 
+    - name: Debug previous version inputs
+      shell: bash
+      run: |
+        echo "DEPLOY_PREVIOUS: '${{ inputs.DEPLOY_PREVIOUS }}'"
+        echo "PREV_VERSION_ID: '${{ inputs.PREV_VERSION_ID }}'"
+        echo "PREV_IMAGE: '${{ inputs.PREV_IMAGE }}'"
+
     # Checkout the previous version to ensure matching nais config is used
     - name: Checkout previous version
       if:  inputs.DEPLOY_PREVIOUS && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -1,4 +1,5 @@
 name: Deploy to Nais
+description: Composite action to deploy application to Nais cluster with optional previous version deployment
 
 inputs:
   DEPLOY_INSTANCE:
@@ -11,17 +12,17 @@ inputs:
     description: Container image (with tag).
     required: true
   DEPLOY_PREVIOUS:
-    description: Whether to deploy previous internal version first.
+    description: Whether to deploy previous version of dekoratøren as well.
     required: false
     default: "false"
   HPA_FILE:
     description: Optional HPA file name under .nais/hpa/.
     required: false
   PREV_VERSION_ID:
-    description: Previously deployed commit SHA (for internal deploy).
+    description: Previously deployed commit SHA (for previous version deploy).
     required: false
   PREV_IMAGE:
-    description: Previously deployed image (for internal deploy).
+    description: Previously deployed image (for previous version deploy).
     required: false
   VARS_UPDATE_TOKEN:
     description: Token (PAT) with permissions to update variables.

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: Container image (with tag).
     required: true
   DEPLOY_PREVIOUS:
-    description: Whether to deploy previous version of dekoratøren as well.
+    description: Whether to deploy previous version of dekoratøren.
     required: false
     default: "false"
   HPA_FILE:
@@ -42,13 +42,6 @@ runs:
       run: |
         echo "version_id=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
         echo "VERSION_ID=$GITHUB_SHA" >> "$GITHUB_ENV"
-
-    - name: Debug previous version inputs
-      shell: bash
-      run: |
-        echo "DEPLOY_PREVIOUS: '${{ inputs.DEPLOY_PREVIOUS }}'"
-        echo "PREV_VERSION_ID: '${{ inputs.PREV_VERSION_ID }}'"
-        echo "PREV_IMAGE: '${{ inputs.PREV_IMAGE }}'"
 
     # Checkout the previous version to ensure matching nais config is used
     - name: Checkout previous version

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -69,7 +69,7 @@ runs:
     - name: Wait for previous deployment to stabilize
       if: inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
       shell: bash
-      run: sleep 30
+      run: sleep 10
 
     # Checkout the current version
     - name: Checkout current repo

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -45,13 +45,13 @@ runs:
 
     # Checkout the previous version to ensure matching nais config is used
     - name: Checkout previous version
-      if:  inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
+      if:  inputs.DEPLOY_PREVIOUS && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.PREV_VERSION_ID }}
 
     - name: Deploy previous version
-      if: inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
+      if: inputs.DEPLOY_PREVIOUS && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
       uses: nais/deploy/actions/deploy@v2
       env:
         CLUSTER: ${{ inputs.CLUSTER }}

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -52,13 +52,13 @@ runs:
 
     # Checkout the previous version to ensure matching nais config is used
     - name: Checkout previous version
-      if:  inputs.DEPLOY_PREVIOUS && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
+      if: inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.PREV_VERSION_ID }}
 
     - name: Deploy previous version
-      if: inputs.DEPLOY_PREVIOUS && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
+      if: inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
       uses: nais/deploy/actions/deploy@v2
       env:
         CLUSTER: ${{ inputs.CLUSTER }}

--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -66,6 +66,11 @@ runs:
         VAR: image=${{ inputs.PREV_IMAGE }},versionId=${{ inputs.PREV_VERSION_ID }},deployInstance=${{ inputs.DEPLOY_INSTANCE }}
         VARS: .nais/vars/${{ inputs.DEPLOY_INSTANCE }}.yml
 
+    - name: Wait for previous deployment to stabilize
+      if: inputs.DEPLOY_PREVIOUS == 'true' && inputs.PREV_VERSION_ID != '' && inputs.PREV_IMAGE != ''
+      shell: bash
+      run: sleep 30
+
     # Checkout the current version
     - name: Checkout current repo
       uses: actions/checkout@v4

--- a/.github/workflows/deploy.beta.navno.yml
+++ b/.github/workflows/deploy.beta.navno.yml
@@ -41,9 +41,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-
       - name: Deploy to Nais
         uses: ./.github/actions/deploy-to-nais
         with:

--- a/.github/workflows/deploy.beta.navno.yml
+++ b/.github/workflows/deploy.beta.navno.yml
@@ -29,13 +29,14 @@ jobs:
         uses: ./.github/actions/build-test
         with:
           READER_TOKEN: ${{ secrets.READER_TOKEN }}
-          TAG_LATEST: "true"
+          TAG_LATEST: true
           IMAGE_SUFFIX: dev-beta-navno
           SKIP_TESTS: ${{ inputs.SKIP_TESTS }}
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    environment: dev-beta-navno
     permissions:
       id-token: write
       contents: read
@@ -50,4 +51,6 @@ jobs:
           CLUSTER: dev-gcp
           IMAGE: ${{ needs.build.outputs.IMAGE }}
           DEPLOY_PREVIOUS: ${{ inputs.DEPLOY_PREVIOUS }}
+          PREV_VERSION_ID: ${{ vars.PREV_VERSION_ID }}
+          PREV_IMAGE: ${{ vars.PREV_IMAGE }}
           VARS_UPDATE_TOKEN: ${{ secrets.VARS_UPDATE_TOKEN }}

--- a/.github/workflows/deploy.beta.navno.yml
+++ b/.github/workflows/deploy.beta.navno.yml
@@ -41,6 +41,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
       - name: Deploy to Nais
         uses: ./.github/actions/deploy-to-nais
         with:

--- a/.github/workflows/deploy.beta.tms.yml
+++ b/.github/workflows/deploy.beta.tms.yml
@@ -35,6 +35,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    environment: dev-beta-tms
     permissions:
       id-token: write
       contents: read
@@ -49,4 +50,6 @@ jobs:
           CLUSTER: dev-gcp
           IMAGE: ${{ needs.build.outputs.IMAGE }}
           DEPLOY_PREVIOUS: ${{ inputs.DEPLOY_PREVIOUS }}
+          PREV_VERSION_ID: ${{ vars.PREV_VERSION_ID }}
+          PREV_IMAGE: ${{ vars.PREV_IMAGE }}
           VARS_UPDATE_TOKEN: ${{ secrets.VARS_UPDATE_TOKEN }}

--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -6,6 +6,7 @@ on:
         description: "Deploy previous version to internal"
         required: false
         type: boolean
+        default: true
       SKIP_TESTS:
         description: "Skip tests"
         required: false

--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -34,6 +34,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    environment: dev-stable
     permissions:
       id-token: write
       contents: read
@@ -48,5 +49,7 @@ jobs:
           CLUSTER: dev-gcp
           IMAGE: ${{ needs.build.outputs.IMAGE }}
           DEPLOY_PREVIOUS: ${{ inputs.DEPLOY_PREVIOUS }}
+          PREV_VERSION_ID: ${{ vars.PREV_VERSION_ID }}
+          PREV_IMAGE: ${{ vars.PREV_IMAGE }}
           HPA_FILE: hpa-dev-stable.yml
           VARS_UPDATE_TOKEN: ${{ secrets.VARS_UPDATE_TOKEN }}

--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -24,11 +24,12 @@ jobs:
         with:
           READER_TOKEN: ${{ secrets.READER_TOKEN }}
           IMAGE_SUFFIX: prod
-          TAG_LATEST: 'true'
+          TAG_LATEST: true
 
   deploy-prod:
     runs-on: ubuntu-latest
     needs: build
+    environment: prod
     permissions:
       id-token: write
       contents: read
@@ -43,6 +44,8 @@ jobs:
           CLUSTER: prod-gcp
           IMAGE: ${{ needs.build.outputs.IMAGE }}
           DEPLOY_PREVIOUS: true
+          PREV_VERSION_ID: ${{ vars.PREV_VERSION_ID }}
+          PREV_IMAGE: ${{ vars.PREV_IMAGE }}
           HPA_FILE: hpa-prod.yml
           VARS_UPDATE_TOKEN: ${{ secrets.VARS_UPDATE_TOKEN }}
 

--- a/.nais/config-internal.yml
+++ b/.nais/config-internal.yml
@@ -73,3 +73,4 @@ spec:
     limits:
       memory: {{limits.memory}}
   {{/with}}
+  

--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -42,7 +42,7 @@ env:
     value: C1302192-8BEC-4EA2-84AB-F4EDE8AC6230
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
-ttlInternal: 1h
+ttlInternal: 2h
 replicas:
   min: 1
   max: 1

--- a/.nais/vars/dev-beta-tms.yml
+++ b/.nais/vars/dev-beta-tms.yml
@@ -40,7 +40,7 @@ env:
     value: "navtest"
   - name: PUZZEL_CUSTOMER_ID
     value: C1302192-8BEC-4EA2-84AB-F4EDE8AC6230
-ttlInternal: 1h
+ttlInternal: 2h
 replicas:
   min: 1
   max: 1

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -43,7 +43,7 @@ env:
     value: 83BD7664-B38B-4EEE-8D99-200669A32551
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
-ttlInternal: 1h
+ttlInternal: 12h
 resources:
   requests:
     cpu: 200m


### PR DESCRIPTION
Etter refactoren fra workflow/jobs til actions så har previous_version sluttet å deploye. Med riggen vi har i dag trenger vi den for at styling ikke skal feile.

- Presiserer miljøene på nytt slik at disse kommer korrekt inn under "Deploys"
- Tilgjengeliggjøre PREVIOUS_VERSION_ID og PREVIOUS_IMAGE for action
- Øker ttl for dev. Med én time vil det fortsatt feile i enkelte apper som har litt for hard caching.
- Justering av diverse kommentar/navning for bedre forståelse.