### PR TITLE
Fjerner feil bruk av role menu fra språkvelgeren

### DIFF
--- a/packages/client/src/views/language-selector.ts
+++ b/packages/client/src/views/language-selector.ts
@@ -145,7 +145,6 @@ export class LanguageSelector extends HTMLElement {
         } else {
             this.menu = document.createElement("ul");
             this.menu.classList.add(cls.menu, utils.hidden);
-            this.menu.setAttribute("role", "menu");
             this.menu.id = "decorator-language-menu";
             this.container.appendChild(this.menu);
         }

--- a/packages/server/src/views/language-selector.ts
+++ b/packages/server/src/views/language-selector.ts
@@ -59,7 +59,6 @@ export const LanguageSelector = ({
                 type="button"
                 class="${cls.button}"
                 aria-expanded="false"
-                aria-haspopup="menu"
                 aria-controls="decorator-language-menu"
             >
                 ${GlobeIcon({ className: utils.icon })}
@@ -70,7 +69,6 @@ export const LanguageSelector = ({
             </button>
             <ul
                 class="${clsx(cls.menu, utils.hidden)}"
-                role="menu"
                 id="decorator-language-menu"
             >
                 ${availableLanguages.map((lang) =>


### PR DESCRIPTION
Fikser følgene problem fra https://wave.webaim.org/report#/https://www.nav.no/ - Broken ARIA menu:

What It Means
An ARIA menu does not contain required menu items.

Why It Matters
ARIA menus are application menus (like those used in software menu) with a specific keyboard interactions. They are NOT for navigation links on a web site and must contain at least one menuitem, menuitemcheckbox, or menuitemradio element.

What To Do
Ensure that the menu is an application menu and has the appropriate keyboard interactions (menu items are navigated via the arrow keys, not via the Tab key) and internal menu items, otherwise remove the menu role.

The Algorithm... in English
An element with role="menu" does not contain at least one element with role="menuitem", role="menuitemcheckbox", or role="menuitemradio".