### PR TITLE
Sende ping til til Umami ved samtykke + bytte til reops-proxy

### DIFF
--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -43,7 +43,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.intern.dev.nav.no/api/send
+    value: https://reops-event-proxy.intern.dev.nav.no
 ttlInternal: 2h
 replicas:
   min: 1

--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -43,7 +43,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.intern.dev.nav.no
+    value: https://reops-event-proxy.ekstern.dev.nav.no
 ttlInternal: 2h
 replicas:
   min: 1

--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -42,6 +42,8 @@ env:
     value: C1302192-8BEC-4EA2-84AB-F4EDE8AC6230
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
+  - name: UMAMI_PROXY_HOST
+    value: https://reops-event-proxy.intern.dev.nav.no/api/send
 ttlInternal: 2h
 replicas:
   min: 1

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -43,6 +43,8 @@ env:
     value: 83BD7664-B38B-4EEE-8D99-200669A32551
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
+  - name: UMAMI_PROXY_HOST
+    value: https://reops-event-proxy.intern.dev.nav.no/api/send
 ttlInternal: 12h
 resources:
   requests:

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -44,7 +44,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.intern.dev.nav.no
+    value: https://reops-event-proxy.ekstern.dev.nav.no
 ttlInternal: 12h
 resources:
   requests:

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -44,7 +44,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: c44a6db3-c974-4316-b433-214f87e80b4d
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.intern.dev.nav.no/api/send
+    value: https://reops-event-proxy.intern.dev.nav.no
 ttlInternal: 12h
 resources:
   requests:

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -41,7 +41,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: 35abb2b7-3f97-42ce-931b-cf547d40d967
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.nav.no/api/send
+    value: https://reops-event-proxy.nav.no
 ttlInternal: 168h
 resources:
   requests:

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -40,6 +40,8 @@ env:
     value: 83BD7664-B38B-4EEE-8D99-200669A32551
   - name: UMAMI_WEBSITE_ID
     value: 35abb2b7-3f97-42ce-931b-cf547d40d967
+  - name: UMAMI_PROXY_HOST
+    value: https://reops-event-proxy.nav.no/api/send
 ttlInternal: 168h
 resources:
   requests:

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -41,7 +41,7 @@ env:
   - name: UMAMI_WEBSITE_ID
     value: 35abb2b7-3f97-42ce-931b-cf547d40d967
   - name: UMAMI_PROXY_HOST
-    value: https://reops-event-proxy.nav.no
+    value: https://umami.nav.no
 ttlInternal: 168h
 resources:
   requests:

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -91,7 +91,7 @@ export const initUmami = () => {
         script.src =
             "https://cdn.nav.no/team-researchops/sporing/sporing-uten-uuid.js";
         script.defer = true;
-        script.setAttribute("data-host-url", "https://umami.nav.no");
+        script.setAttribute("data-host-url", `${env("UMAMI_PROXY_HOST")}`);
         script.setAttribute("data-website-id", `${env("UMAMI_WEBSITE_ID")}`);
         script.setAttribute("data-auto-track", "false");
         document.head.appendChild(script);

--- a/packages/server/.env.sample
+++ b/packages/server/.env.sample
@@ -18,6 +18,7 @@ UNLEASH_SERVER_API_URL=http://localhost:8095/unleash
 UNLEASH_SERVER_API_TOKEN=dummy_token
 
 UMAMI_WEBSITE_ID=c44a6db3-c974-4316-b433-214f87e80b4d
+UMAMI_PROXY_HOST=https://reops-event-proxy.intern.dev.nav.no/api/send
 BOOST_ENV=navtest
 PUZZEL_CUSTOMER_ID=C1302192-8BEC-4EA2-84AB-F4EDE8AC6230
 VERSION_ID=asdf

--- a/packages/server/src/env/schema.ts
+++ b/packages/server/src/env/schema.ts
@@ -52,4 +52,5 @@ export const client_env = {
     VERSION_ID: process.env.VERSION_ID,
     XP_BASE_URL: process.env.XP_BASE_URL,
     UMAMI_WEBSITE_ID: process.env.UMAMI_WEBSITE_ID,
+    UMAMI_PROXY_HOST: process.env.UMAMI_PROXY_HOST,
 } satisfies Record<keyof Environment, unknown>;

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -37,6 +37,7 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             },
             body: JSON.stringify(umamiEvent),
         });
+        logger.info("Sent consentping to Umami");
     } catch (error) {
         logger.error("Failed to send consentping:", { error });
         return json({});

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -1,0 +1,26 @@
+import { Consent } from "decorator-shared/types";
+import { Handler } from "hono";
+
+export const consentpingHandler: Handler = async ({ req, json }) => {
+    const body = (await req.json()) as any;
+    if (!body?.consentObject) {
+        return json({
+            result: "error",
+            message: "Missing consentObject in request body",
+        });
+    }
+
+    const { consentObject } = body as { consentObject: Consent };
+
+    const umamiEvent = {
+        type: "cookie-consent-event",
+        payload: {
+            website: process.env.UMAMI_WEBSITE_ID,
+            data: {
+                consentObject,
+            },
+        },
+    };
+
+    return json({ result: "ok" });
+};

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -17,9 +17,10 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
     const umamiEvent = {
         type: "event",
         payload: {
-            name: "consentping",
+            name: "cookiebanner",
             hostname: "www.nav.no",
-            title: "consentping",
+            url: "/",
+            referrer: "https://www.nav.no",
             website: process.env.UMAMI_WEBSITE_ID,
             data: {
                 consentObject,
@@ -37,7 +38,9 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             },
             body: JSON.stringify(umamiEvent),
         });
-        logger.info("Sent consentping to Umami");
+        logger.info(
+            `Sendt umami cookiebanner: ${umamiEndpoint}, ${JSON.stringify(umamiEvent)}`,
+        );
     } catch (error) {
         logger.error("Failed to send consentping:", { error });
         return json({});

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -38,9 +38,11 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             },
             body: JSON.stringify(umamiEvent),
         });
-        logger.info(
-            `Sendt umami cookiebanner: ${umamiEndpoint}, ${JSON.stringify(umamiEvent)}, response status: ${umamiResponse.status}`,
-        );
+        if (!umamiResponse.ok) {
+            logger.error("Failed to send consentping:", {
+                error: `HTTP ${umamiResponse.status} - ${umamiResponse.statusText}`,
+            });
+        }
     } catch (error) {
         logger.error("Failed to send consentping:", { error });
         return json({});

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -31,7 +31,7 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
     const umamiEndpoint = `${process.env.UMAMI_PROXY_HOST}/api/send`;
 
     try {
-        await fetch(umamiEndpoint, {
+        const umamiResponse = await fetch(umamiEndpoint, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -39,7 +39,7 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             body: JSON.stringify(umamiEvent),
         });
         logger.info(
-            `Sendt umami cookiebanner: ${umamiEndpoint}, ${JSON.stringify(umamiEvent)}`,
+            `Sendt umami cookiebanner: ${umamiEndpoint}, ${JSON.stringify(umamiEvent)}, response status: ${umamiResponse.status}`,
         );
     } catch (error) {
         logger.error("Failed to send consentping:", { error });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -65,7 +65,7 @@ app.get("/api/ta", ({ json }) => {
     return json(getTaskAnalyticsSurveys());
 });
 
-// app.post("/api/consentping", consentpingHandler);
+app.post("/api/consentping", consentpingHandler);
 
 app.post("/api/notifications/:id/archive", async ({ req, json }) => {
     const result = await archiveNotification({

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,6 +28,7 @@ import { versionApiHandler } from "./handlers/version-api-handler";
 import { MainMenuTemplate } from "./views/header/render-main-menu";
 import { buildDecoratorData } from "./decorator-data";
 import { CONSUMER } from "decorator-shared/constants";
+import { consentpingHandler } from "./handlers/consentping-handler";
 
 const app = new Hono({
     strict: false,
@@ -64,21 +65,7 @@ app.get("/api/ta", ({ json }) => {
     return json(getTaskAnalyticsSurveys());
 });
 
-app.post("/api/consentping", async ({ req, json }) => {
-    const consentPingbackUrl = `${env.DEKORATOREN_API_URL}/consent`;
-    const body = await req.json();
-
-    await fetch(consentPingbackUrl, {
-        body: JSON.stringify(body),
-        headers: {
-            "Content-Type": "application/json",
-        },
-        method: "POST",
-        credentials: "omit",
-    });
-
-    return json({ result: "ok" });
-});
+// app.post("/api/consentping", consentpingHandler);
 
 app.post("/api/notifications/:id/archive", async ({ req, json }) => {
     const result = await archiveNotification({

--- a/packages/shared/params.ts
+++ b/packages/shared/params.ts
@@ -116,6 +116,7 @@ export const clientEnvSchema = z.object({
     MIN_SIDE_URL: z.string(),
     PUZZEL_CUSTOMER_ID: z.string(),
     UMAMI_WEBSITE_ID: z.string().optional(),
+    UMAMI_PROXY_HOST: z.string().optional(),
     VERSION_ID: z.string(),
     XP_BASE_URL: z.string(),
 });


### PR DESCRIPTION
- Sender ping til Umami for å kunne bedre logge hvem som aksepterer eller ikke. Gjøres på serversiden slik at vi ikke har noen persondata, selv ikke ip.
- Introduserer proxy-endepunkter for prod og dev.

Dette betyr at Umami-data i dev vil finnes på https://metabase.ansatt.dev.nav.no/browse/databases