### PR TITLE
Legge til user agent i consent ping

### DIFF
--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -41,12 +41,16 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             body: JSON.stringify(umamiEvent),
         });
         if (!umamiResponse.ok) {
-            logger.error("Failed to send consentping:", {
+            logger.error("consentping: Failed to send consentping:", {
                 error: `HTTP ${umamiResponse.status} - ${umamiResponse.statusText}`,
             });
+        } else {
+            logger.info(
+                `consentping: Successfully sent consentping to Umami: ${JSON.stringify(umamiResponse)}`,
+            );
         }
     } catch (error) {
-        logger.error("Failed to send consentping:", { error });
+        logger.error("consentping: Failed to send consentping:", { error });
         return json({});
     }
 

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -35,6 +35,8 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
+                "User-Agent":
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
             },
             body: JSON.stringify(umamiEvent),
         });

--- a/packages/server/src/handlers/consentping-handler.ts
+++ b/packages/server/src/handlers/consentping-handler.ts
@@ -45,8 +45,9 @@ export const consentpingHandler: Handler = async ({ req, json }) => {
                 error: `HTTP ${umamiResponse.status} - ${umamiResponse.statusText}`,
             });
         } else {
+            const umamiResponseData = await umamiResponse.text();
             logger.info(
-                `consentping: Successfully sent consentping to Umami: ${JSON.stringify(umamiResponse)}`,
+                `consentping: Successfully sent consentping to Umami: ${umamiResponseData}`,
             );
         }
     } catch (error) {


### PR DESCRIPTION
Umami ser ut til å forkaste events i stillhet dersom User-Agent ikke er med. Forsøker å legge på dette nå, i tillegg til utvidet midlertidig logging for feilsøking.