### PR TITLE
Fikser feil språkeksempel i docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ class MyDocument extends Document<DocumentProps> {
 
         const Decorator = await fetchDecoratorReact({
             env: "prod",
-            params: { language: "no", context: "arbeidsgiver" },
+            params: { language: "nb", context: "arbeidsgiver" },
         });
 
         return { ...initialProps, Decorator };


### PR DESCRIPTION
Eksempelet setter 'no' som språk. Vi støtter `nb` eller `nn` for likestilte målformer. `no` vil gi 500-feil så fjernes fra docs.