### PR TITLE
Bugfix - Frida knapp ikke synlig

### DIFF
--- a/packages/client/src/views/chatbot/chatbot.test.ts
+++ b/packages/client/src/views/chatbot/chatbot.test.ts
@@ -71,6 +71,15 @@ describe("chatbot", () => {
         expect(child.classList).toContain(cls.visible);
     });
 
+    it("stays visible when unrelated params are updated", async () => {
+        const el = await fixture("<d-chatbot></d-chatbot>");
+        const child = el.childNodes[0] as HTMLElement;
+        expect(child.classList).toContain(cls.visible);
+
+        updateDecoratorParams({ language: "en" });
+        expect(child.classList).toContain(cls.visible);
+    });
+
     it("doesnt mount when feature is not toggled", async () => {
         window.__DECORATOR_DATA__.features["dekoratoren.chatbotscript"] = false;
         const el = await fixture("<d-chatbot></d-chatbot>");

--- a/packages/client/src/views/chatbot/chatbot.ts
+++ b/packages/client/src/views/chatbot/chatbot.ts
@@ -46,7 +46,7 @@ class Chatbot extends HTMLElement {
     private paramsUpdatedListener = (event: CustomEvent) =>
         this.update(event.detail.params);
 
-    private update = ({ chatbot, chatbotVisible }: Partial<ClientParams>) => {
+    private update = ({ chatbot }: Partial<ClientParams>) => {
         if (
             !window.__DECORATOR_DATA__.features["dekoratoren.chatbotscript"] ||
             chatbot === false
@@ -56,7 +56,9 @@ class Chatbot extends HTMLElement {
             this.appendChild(this.button);
         }
 
-        const isVisible = chatbotVisible || hasActiveConversation();
+        const isVisible =
+            window.__DECORATOR_DATA__.params.chatbotVisible ||
+            hasActiveConversation();
         this.button.classList.toggle(cls.visible, isVisible);
 
         if (isVisible) {


### PR DESCRIPTION
 ## Problem
Frida-knappen forsvinner dersom man legger ned samtale-vinduet og navigerer til en annen side. Samtalen er fortsatt aktiv, men bruker må åpne vinduet igjen via kontakt oss.

Rotårsaken var at `chatbotVisible` ble undefined i `update`-metoden i `chatbot.ts` når andre parametre oppdateres. Har løst dette ved å lese `chatbotVisible` direkte fra `window.__DECORATOR_DATA__.params` i stedet for fra `ClientParams`.
 
 ## Steg for å reprodusere
 
 1. Åpne en ny chat og godta samtykker
 2. Skriv en melding, f.eks. "Test"
 3. Legg ned chat-vinduet ved å trykke `_`
   i. Dersom du er i dev-miljø må man slette `boostai.conversation.id` session token. Dette brukes ikke i produksjon.
 5. Naviger til en annen side
 
 **Forventet oppførsel:**
 Chatbot-knappen forblir synlig.
 
 **Faktisk oppførsel:**
 Chatbot-knappen forsvinner.
 
 ## Endringer
 
 - Lagt til en feilende test som viser buggen
 - Fikset `chatbot.ts` til å lese `chatbotVisible` fra global tilstand
