### PR TITLE
Lagt til støtte for logging av intern metadata

### DIFF
--- a/packages/client/src/analytics/analytics.test.ts
+++ b/packages/client/src/analytics/analytics.test.ts
@@ -1,0 +1,144 @@
+import type { Auth } from "decorator-shared/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { initAnalytics } from "./analytics";
+import { logUmamiEvent } from "./umami";
+
+vi.mock("./amplitude", () => ({
+    initMockAmplitude: vi.fn(),
+}));
+
+vi.mock("./task-analytics/ta", () => ({
+    initTaskAnalyticsScript: vi.fn(),
+    stopTaskAnalytics: vi.fn(),
+}));
+
+vi.mock("./umami", () => ({
+    createUmamiEvent: vi.fn(),
+    initUmami: vi.fn(),
+    logUmamiEvent: vi.fn(),
+    stopUmami: vi.fn(),
+}));
+
+const auth: Auth = {
+    authenticated: true,
+    name: "Test Testesen",
+    userId: "123",
+    securityLevel: "4",
+};
+
+const setupDecoratorData = () => {
+    window.__DECORATOR_DATA__ = {
+        params: {
+            simple: false,
+            simpleHeader: false,
+            simpleFooter: false,
+            redirectToApp: false,
+            level: "Level4",
+            context: "privatperson",
+            language: "nb",
+            pageType: "article",
+            pageTitle: "Page title",
+            pageTheme: "theme",
+            breadcrumbs: [],
+            availableLanguages: [],
+            utilsBackground: "transparent",
+            chatbot: true,
+            chatbotVisible: false,
+            shareScreen: true,
+            logoutWarning: true,
+            feedback: false,
+            ssrMainMenu: false,
+            redirectOnUserChange: false,
+            analyticsQueryParams: [],
+            analyticsRedactFilter: [],
+            decoratorModulerVersion: "4.1.1",
+            decoratorModulerEntryPoint: "ssr",
+        },
+        features: {
+            "dekoratoren.skjermdeling": false,
+            "dekoratoren.chatbotscript": false,
+            "dekoratoren.umami": false,
+            "dekoratoren.puzzel-script": false,
+        },
+        env: {} as any,
+        texts: {} as any,
+        allowedStorage: [],
+    };
+    (
+        window.__DECORATOR_DATA__.params as Record<string, unknown>
+    ).decoratorModulerAnalyticsEntryPoint = "typed";
+};
+
+describe("analytics", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        setupDecoratorData();
+    });
+
+    it("logs pageviews with moduler metadata outside parametre", () => {
+        initAnalytics(auth);
+
+        vi.advanceTimersByTime(100);
+
+        expect(logUmamiEvent).toHaveBeenCalledWith(
+            "besøk",
+            expect.objectContaining({
+                målgruppe: "privatperson",
+                innholdstype: "article",
+                sidetittel: "Page title",
+                tema: "theme",
+                innlogging: "4",
+                parametre: expect.not.objectContaining({
+                    decoratorModulerVersion: expect.anything(),
+                    decoratorModulerEntryPoint: expect.anything(),
+                    decoratorModulerAnalyticsEntryPoint: expect.anything(),
+                }),
+            }),
+            "nav-dekoratoren",
+            {
+                decoratorModulerVersion: "4.1.1",
+                decoratorModulerEntryPoint: "ssr",
+            },
+        );
+    });
+
+    it.each(["typed", "custom", "legacy"] as const)(
+        "forwards valid analytics entry point %s from app events",
+        async (analyticsEntryPoint) => {
+            initAnalytics(auth);
+
+            await window.dekoratorenAnalytics({
+                origin: "test-app",
+                eventName: "test-event",
+                decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
+            });
+
+            expect(logUmamiEvent).toHaveBeenCalledWith(
+                "test-event",
+                {},
+                "test-app",
+                {
+                    decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
+                },
+            );
+        },
+    );
+
+    it("ignores invalid analytics entry point without dropping the app event", async () => {
+        initAnalytics(auth);
+
+        await window.dekoratorenAnalytics({
+            origin: "test-app",
+            eventName: "test-event",
+            decoratorModulerAnalyticsEntryPoint: "invalid",
+        } as any);
+
+        expect(logUmamiEvent).toHaveBeenCalledWith(
+            "test-event",
+            {},
+            "test-app",
+            undefined,
+        );
+    });
+});

--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -4,9 +4,15 @@ import {
 } from "./task-analytics/ta";
 import { initMockAmplitude } from "./amplitude";
 import { createUmamiEvent, initUmami, logUmamiEvent, stopUmami } from "./umami";
+import { DEFAULT_ORIGIN } from "./constants";
 import { Auth } from "decorator-shared/auth";
 import { AnalyticsEventArgs, EventData } from "./types";
 import { param } from "../params";
+import {
+    analyticsEntryPointSchema,
+    type ClientParams,
+    type ModulerMetadata,
+} from "decorator-shared/params";
 
 declare global {
     interface Window {
@@ -88,6 +94,22 @@ export const extraWindowParams = () => {
     };
 };
 
+const excludedParametre = new Set<string>([
+    "decoratorModulerVersion",
+    "decoratorModulerEntryPoint",
+    "decoratorModulerAnalyticsEntryPoint",
+]);
+
+const buildPageviewParametre = (params: ClientParams) =>
+    Object.fromEntries(
+        Object.entries(params).filter(([key]) => !excludedParametre.has(key)),
+    );
+
+const parseAnalyticsEntryPoint = (
+    value: unknown,
+): ModulerMetadata["decoratorModulerAnalyticsEntryPoint"] | undefined =>
+    analyticsEntryPointSchema.safeParse(value).data;
+
 const logPageView = (authState: Auth) => {
     // Må vente litt med logging for å sikre at window-objektet er oppdatert.
     setTimeout(() => {
@@ -101,7 +123,7 @@ const logPageView = (authState: Auth) => {
                 ? authState.securityLevel
                 : false,
             parametre: {
-                ...params,
+                ...buildPageviewParametre(params),
                 BREADCRUMBS:
                     params.breadcrumbs && params.breadcrumbs.length > 0,
                 ...(params.availableLanguages && {
@@ -111,7 +133,10 @@ const logPageView = (authState: Auth) => {
                 }),
             },
         };
-        logUmamiEvent("besøk", eventData);
+        logUmamiEvent("besøk", eventData, DEFAULT_ORIGIN, {
+            decoratorModulerVersion: params.decoratorModulerVersion,
+            decoratorModulerEntryPoint: params.decoratorModulerEntryPoint,
+        });
     }, 100);
 };
 
@@ -122,9 +147,10 @@ export const analyticsEvent = (props: AnalyticsEventArgs) => {
 export const logAnalyticsEvent = async (
     eventName: string,
     eventData: EventData = {},
-    origin = "nav-dekoratoren",
+    origin = DEFAULT_ORIGIN,
+    decoratorModuler?: ModulerMetadata,
 ) => {
-    logUmamiEvent(eventName, eventData, origin);
+    logUmamiEvent(eventName, eventData, origin, decoratorModuler);
 };
 
 export const analyticsClickListener =
@@ -152,9 +178,12 @@ export const analyticsClickListener =
     };
 
 const logAnalyticsEventFromApp = (params?: {
-    origin: unknown | string;
-    eventName: unknown | string;
+    origin: string;
+    eventName: string;
     eventData?: unknown | EventData;
+    decoratorModulerAnalyticsEntryPoint?:
+        | unknown
+        | ModulerMetadata["decoratorModulerAnalyticsEntryPoint"];
 }): Promise<any> => {
     try {
         if (!params || params.constructor !== Object) {
@@ -163,7 +192,12 @@ const logAnalyticsEventFromApp = (params?: {
             );
         }
 
-        const { origin, eventName, eventData = {} } = params;
+        const {
+            origin,
+            eventName,
+            eventData = {},
+            decoratorModulerAnalyticsEntryPoint: analyticsEntryPointParam,
+        } = params;
         if (!eventName || typeof eventName !== "string") {
             return Promise.reject('Parameter "eventName" must be a string');
         }
@@ -175,8 +209,20 @@ const logAnalyticsEventFromApp = (params?: {
                 'Parameter "eventData" must be a plain object',
             );
         }
+        const analyticsEntryPoint = parseAnalyticsEntryPoint(
+            analyticsEntryPointParam,
+        );
 
-        return logAnalyticsEvent(eventName, eventData, origin);
+        return logAnalyticsEvent(
+            eventName,
+            eventData,
+            origin,
+            analyticsEntryPoint
+                ? {
+                      decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
+                  }
+                : undefined,
+        );
     } catch (e) {
         return Promise.reject(`Unexpected Analytics error: ${e}`);
     }

--- a/packages/client/src/analytics/analytics.ts
+++ b/packages/client/src/analytics/analytics.ts
@@ -94,6 +94,7 @@ export const extraWindowParams = () => {
     };
 };
 
+// Moduler-metadata logges som egne Umami-felter og skal derfor ikke dupliseres i pageview-parametre.
 const excludedParametre = new Set<string>([
     "decoratorModulerVersion",
     "decoratorModulerEntryPoint",

--- a/packages/client/src/analytics/constants.ts
+++ b/packages/client/src/analytics/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ORIGIN = "nav-dekoratoren";

--- a/packages/client/src/analytics/umami.test.ts
+++ b/packages/client/src/analytics/umami.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logUmamiEvent } from "./umami";
+
+describe("logUmamiEvent", () => {
+    beforeEach(() => {
+        window.__DECORATOR_DATA__ = {
+            params: {
+                analyticsQueryParams: [],
+                analyticsRedactFilter: [],
+            },
+            features: {
+                "dekoratoren.umami": true,
+            },
+        } as unknown as typeof window.__DECORATOR_DATA__;
+        window.webStorageController = {
+            getAnalyticsId: () => "analytics-id",
+        } as typeof window.webStorageController;
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("adds moduler metadata to the Umami payload", async () => {
+        const track = vi.fn((createEvent) =>
+            createEvent({
+                referrer: "https://www.nav.no/referrer?fnr=12345678910",
+            }),
+        );
+        vi.stubGlobal("umami", { track });
+
+        const event = await logUmamiEvent(
+            "besøk",
+            { målgruppe: "privatperson" },
+            "nav-dekoratoren",
+            {
+                decoratorModulerVersion: "4.1.1",
+                decoratorModulerEntryPoint: "ssr",
+            },
+        );
+
+        expect(track).toHaveBeenCalledOnce();
+        expect(event).toMatchObject({
+            id: "analytics-id",
+            data: {
+                målgruppe: "privatperson",
+                origin: "nav-dekoratoren",
+                viaDekoratoren: true,
+                decoratorModulerVersion: "4.1.1",
+                decoratorModulerEntryPoint: "ssr",
+            },
+        });
+    });
+
+    it.each(["typed", "custom", "legacy"] as const)(
+        "adds analytics entry point %s to the Umami payload",
+        async (analyticsEntryPoint) => {
+            const track = vi.fn((createEvent) =>
+                createEvent({
+                    referrer: "https://www.nav.no/referrer",
+                }),
+            );
+            vi.stubGlobal("umami", { track });
+
+            const event = await logUmamiEvent(
+                "test-event",
+                { kategori: "test" },
+                "test-app",
+                {
+                    decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
+                },
+            );
+
+            expect(track).toHaveBeenCalledOnce();
+            expect(event).toMatchObject({
+                name: "test-event",
+                data: {
+                    kategori: "test",
+                    origin: "test-app",
+                    viaDekoratoren: true,
+                    decoratorModulerAnalyticsEntryPoint: analyticsEntryPoint,
+                },
+            });
+        },
+    );
+});

--- a/packages/client/src/analytics/umami.ts
+++ b/packages/client/src/analytics/umami.ts
@@ -7,6 +7,8 @@ import {
 import { getDeviceParams } from "./deviceParams";
 import { redactData } from "./helpers/redactData";
 import { AnalyticsEventArgs, EventData } from "./types";
+import type { ModulerMetadata } from "decorator-shared/params";
+import { DEFAULT_ORIGIN } from "./constants";
 
 /*
  * TIL UTVIKLER: ADVARSEL OM PERSONOPPLYSNINGER
@@ -29,7 +31,8 @@ export const redactQueryString = (url: string): string => {
 export const logUmamiEvent = async (
     eventName: string,
     eventData: EventData = {},
-    origin = "nav-dekoratoren",
+    origin = DEFAULT_ORIGIN,
+    decoratorModuler?: ModulerMetadata,
 ) => {
     if (
         window.__DECORATOR_DATA__.features["dekoratoren.umami"] &&
@@ -39,7 +42,8 @@ export const logUmamiEvent = async (
             includeOrigin: false,
             includeHash: false,
         });
-
+        // Internal adoption metadata. Use `besøk` events for
+        // moduler version/entry point stats. Missing analytics entry point means unknown/legacy.
         return umami.track((props) =>
             redactData({
                 ...props,
@@ -59,6 +63,7 @@ export const logUmamiEvent = async (
                     origin,
                     originVersion: eventData.originVersion || "unknown",
                     viaDekoratoren: true,
+                    ...decoratorModuler,
                     ...extraWindowParams(),
                     ...getDeviceParams(),
                 },

--- a/packages/server/src/validateParams.test.ts
+++ b/packages/server/src/validateParams.test.ts
@@ -201,3 +201,53 @@ describe("JSON parsing", () => {
         expect(params.breadcrumbs).toEqual(base);
     });
 });
+
+describe("decorator moduler metadata", () => {
+    it("should parse valid decorator moduler metadata", () => {
+        const params = parseAndValidateParams({
+            decoratorModulerVersion: "4.1.1",
+            decoratorModulerEntryPoint: "ssr",
+        });
+
+        expect(params.decoratorModulerVersion).toBe("4.1.1");
+        expect(params.decoratorModulerEntryPoint).toBe("ssr");
+    });
+
+    it("should keep decorator moduler version when entry point is missing", () => {
+        const params = parseAndValidateParams({
+            decoratorModulerVersion: "4.1.1",
+        });
+
+        expect(params.decoratorModulerVersion).toBe("4.1.1");
+        expect(params.decoratorModulerEntryPoint).toBeUndefined();
+    });
+
+    it("should keep decorator moduler entry point when version is missing", () => {
+        const params = parseAndValidateParams({
+            decoratorModulerEntryPoint: "csr",
+        });
+
+        expect(params.decoratorModulerVersion).toBeUndefined();
+        expect(params.decoratorModulerEntryPoint).toBe("csr");
+    });
+
+    it("should keep valid decorator moduler version when the entry point is invalid", () => {
+        const params = parseAndValidateParams({
+            decoratorModulerVersion: "4.1.1",
+            decoratorModulerEntryPoint: "invalid",
+        });
+
+        expect(params.decoratorModulerVersion).toBe("4.1.1");
+        expect(params.decoratorModulerEntryPoint).toBeUndefined();
+    });
+
+    it("should keep valid decorator moduler entry point when the version is not semver", () => {
+        const params = parseAndValidateParams({
+            decoratorModulerVersion: "not-a-version",
+            decoratorModulerEntryPoint: "ssr",
+        });
+
+        expect(params.decoratorModulerVersion).toBeUndefined();
+        expect(params.decoratorModulerEntryPoint).toBe("ssr");
+    });
+});

--- a/packages/server/src/validateParams.ts
+++ b/packages/server/src/validateParams.ts
@@ -2,6 +2,8 @@ import {
     paramsSchema,
     type Params,
     AvailableLanguage,
+    modulerEntryPointSchema,
+    modulerVersionSemverSchema,
 } from "decorator-shared/params";
 import { clientEnv } from "./env/server";
 import { P, match } from "ts-pattern";
@@ -42,6 +44,12 @@ export const validateParams = (params: Record<string, string>) => {
                 : paramsSchema.shape[key as keyof Params].parse(params[key]),
         };
     }, {});
+    const modulerVersion = modulerVersionSemverSchema.safeParse(
+        params.decoratorModulerVersion,
+    ).data;
+    const modulerEntryPoint = modulerEntryPointSchema.safeParse(
+        params.decoratorModulerEntryPoint,
+    ).data;
 
     return {
         ...params,
@@ -75,6 +83,8 @@ export const validateParams = (params: Record<string, string>) => {
                 }
             })
             .otherwise(() => []),
+        decoratorModulerVersion: modulerVersion,
+        decoratorModulerEntryPoint: modulerEntryPoint,
     } as Params;
 };
 

--- a/packages/shared/params.ts
+++ b/packages/shared/params.ts
@@ -47,6 +47,21 @@ export type UtilsBackground = z.infer<typeof utilsBackground>;
 const loginLevel = z.enum(["Level3", "Level4"]);
 export type LoginLevel = z.infer<typeof loginLevel>;
 
+export const modulerVersionSchema = z.string().min(1).max(50);
+export const modulerVersionSemverSchema = modulerVersionSchema.regex(
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/,
+);
+export const modulerEntryPointSchema = z.enum(["ssr", "csr"]);
+export const analyticsEntryPointSchema = z.enum(["typed", "custom", "legacy"]);
+
+export type ModulerMetadata = {
+    decoratorModulerVersion?: z.infer<typeof modulerVersionSemverSchema>;
+    decoratorModulerEntryPoint?: z.infer<typeof modulerEntryPointSchema>;
+    decoratorModulerAnalyticsEntryPoint?: z.infer<
+        typeof analyticsEntryPointSchema
+    >;
+};
+
 export const paramsSchema = z.object({
     context: contextSchema.default("privatperson"),
     simple: z.boolean().default(false),
@@ -78,6 +93,8 @@ export const paramsSchema = z.object({
     pageTitle: z.string().optional(),
     analyticsQueryParams: z.array(z.string()).default([]),
     analyticsRedactFilter: z.array(z.string()).default([]),
+    decoratorModulerVersion: modulerVersionSemverSchema.optional(),
+    decoratorModulerEntryPoint: modulerEntryPointSchema.optional(),
 });
 
 export type Params = z.infer<typeof paramsSchema>;
@@ -104,6 +121,8 @@ export const clientParamKeys: Array<keyof Params> = [
     "pageTitle",
     "analyticsQueryParams",
     "analyticsRedactFilter",
+    "decoratorModulerVersion",
+    "decoratorModulerEntryPoint",
 ] as const;
 
 export type ClientParams = Pick<Params, (typeof clientParamKeys)[number]>;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,4 +1,4 @@
-import { Environment, ClientParams, Params } from "./params";
+import type { Environment, ClientParams, Params } from "./params";
 import { nb } from "decorator-server/src/texts";
 
 export type Link = {


### PR DESCRIPTION
Legger til mulighet for å logge moduler versjon på "besøk"-event og analytics-metadata for alle events (typed | custom | legacy | undefined)

Se https://github.com/navikt/nav-dekoratoren-moduler/pull/208