### PR TITLE
Riktige farger på logo og knapper i simpleHeader

### DIFF
--- a/packages/server/src/views/header/simple-header.ts
+++ b/packages/server/src/views/header/simple-header.ts
@@ -18,7 +18,7 @@ export const SimpleHeader = ({
     frontPageUrl,
     loginUrl,
 }: SimpleHeaderProps) => html`
-    <div class="${cls.siteheader}">
+    <div class="${cls.siteheader}" data-color="neutral">
         ${SkipLink(i18n("skip_link"))}
         <div class="${cls.hovedmenyWrapper} ${utilsCls.contentContainer}">
             <a href="${frontPageUrl}" class="${cls.logo} ${cls.logoSimple}"

--- a/packages/server/src/views/simple-user-menu.ts
+++ b/packages/server/src/views/simple-user-menu.ts
@@ -10,7 +10,7 @@ export type SimpleUserMenuProps = {
 };
 
 export const SimpleUserMenu = ({ name, logoutUrl }: SimpleUserMenuProps) =>
-    html`<div class="${cls.simpleUserMenu}">
+    html`<div class="${cls.simpleUserMenu}" data-color="accent">
         <span class="${cls.name}">
             <b>${i18n("logged_in")}:</b>
             <span>${name}</span>

--- a/packages/server/src/views/user-menu.ts
+++ b/packages/server/src/views/user-menu.ts
@@ -12,7 +12,7 @@ export const UserMenu = ({ loginUrl }: { loginUrl: string }) => html`
         <span class="${clsx(cls.loader, aksel["aksel-label"])}">
             ${i18n("loading")}
         </span>
-        <login-button class="${utils.hidden}">
+        <login-button class="${utils.hidden}" data-color="accent">
             ${HeaderButton({
                 content: i18n("login"),
                 icon: EnterIcon(),


### PR DESCRIPTION
Styrer `accent`- og `neutral`-theme mer presist, fremfor å arve standard (`accent`) på all tekst i simpleHeader.