### PR TITLE
Sikrer riktige farger ved miks av Aksel-versjoner

### DIFF
--- a/packages/client/src/styles/aksel.module.css
+++ b/packages/client/src/styles/aksel.module.css
@@ -6,6 +6,9 @@
 
 .aksel-button {
     font: inherit;
+
+    /* Hindrer overstyring av tekstfarge fra andre apper der eldre versjoner av Aksel brukes */
+    color: var(--ax-text-subtle);
 }
 
 .aksel-link:focus-visible {

--- a/packages/client/src/styles/complex-footer.module.css
+++ b/packages/client/src/styles/complex-footer.module.css
@@ -18,6 +18,9 @@
     gap: var(--ax-space-8);
     padding: var(--ax-space-16);
     padding-left: 0;
+
+    /* Hindrer overstyring av tekstfarge fra andre apper der eldre versjoner av Aksel brukes */
+    color: var(--ax-text-subtle);
 }
 
 .footerLinks {
@@ -50,6 +53,9 @@
 
 .footerLink {
     padding-block: 0.625rem;
+
+    /* Hindrer overstyring av tekstfarge fra andre apper der eldre versjoner av Aksel brukes */
+    color: var(--ax-text-subtle);
 }
 
 .complexFooterOrg {

--- a/packages/server/src/views/header/complex-header.ts
+++ b/packages/server/src/views/header/complex-header.ts
@@ -37,7 +37,7 @@ export function ComplexHeader({
     mainMenu,
 }: ComplexHeaderProps) {
     return html`
-        <div class="${cls.siteheader}" id="toppen">
+        <div class="${cls.siteheader}" id="toppen" data-color="neutral">
             ${SkipLink(i18n("skip_link"))}
             ${Sticky({
                 children: html`
@@ -75,7 +75,10 @@ export function ComplexHeader({
                                 </context-links>
                             `}
                         </div>
-                        <div class="${menuItemsCls.menuItems}">
+                        <div
+                            class="${menuItemsCls.menuItems}"
+                            data-color="accent"
+                        >
                             ${UserMenu({ loginUrl })}
                             <div
                                 class="${menuItemsCls.menuItemsUniversalLinks}"


### PR DESCRIPTION
Fikser specificity-problemer. Gjentar tekstfarge på noen lenker og knapper fra Aksel v8, siden styling i CSS-layers taper specificity mot styling utenfor.