### PR TITLE
La til steg for deploy network policy

### DIFF
--- a/.github/actions/deploy-to-nais/action.yml
+++ b/.github/actions/deploy-to-nais/action.yml
@@ -75,6 +75,12 @@ runs:
         CLUSTER: ${{ inputs.CLUSTER }}
         RESOURCE: .nais/hpa/${{inputs.HPA_FILE}}
 
+    - name: Deploy network policy
+      uses: nais/deploy/actions/deploy@v2
+      env:
+        CLUSTER: ${{ inputs.CLUSTER }}
+        RESOURCE: .nais/network-policy.yml
+
     - name: Deploy current version
       uses: nais/deploy/actions/deploy@v2
       env:


### PR DESCRIPTION
network-policy.yml ble aldri deployet

.nais/network-policy.yml finnes i repoet men manglet i deploy-actionen. Uten den har ikke main-appen (dekoratorenType: external) egress-tilgang til de interne versjonene (dekoratorenType: internal) – NAIS sin standard accessPolicy tillater kun trafikk til applikasjonene listet i outbound.rules, men de interne versjonene (nav-dekoratoren-<sha>) kan ikke forhåndslistes siden SHA-en ikke er kjent ved deploy-tid.

Fix: Lagt til et steg i .github/actions/deploy-to-nais/action.yml som deployer network-policy.yml til clusteret.