### PR TITLE
La til state for tom varsel-liste

### DIFF
--- a/packages/server/.env.sample
+++ b/packages/server/.env.sample
@@ -24,4 +24,11 @@ BOOST_ENV=navtest
 PUZZEL_CUSTOMER_ID=C1302192-8BEC-4EA2-84AB-F4EDE8AC6230
 VERSION_ID=asdf
 APP_NAME=nav-dekoratoren
+
+# Kontrollerer innlogget bruker-mock.
+# Fjern for å logge ut bruker, sett til 3 for innlogget bruker.
 MOCK_AUTH_LEVEL=3
+
+# Kontrollerer varsel-mock.
+# Sett til "empty" for tom varsel-liste eller "full" for mock-varsler med innhold.
+MOCK_NOTIFICATIONS=full

--- a/packages/server/src/mocks.ts
+++ b/packages/server/src/mocks.ts
@@ -81,7 +81,11 @@ export const setupMocks = () =>
             HttpResponse.json(testData),
         ),
         http.get(`${env.APP_URL}/api/varselbjelle/varsler`, () =>
-            HttpResponse.json(notificationsMock),
+            HttpResponse.json(
+                process.env.MOCK_NOTIFICATIONS === "empty"
+                    ? { oppgaver: [], beskjeder: [] }
+                    : notificationsMock,
+            ),
         ),
         http.get(`${env.APP_URL}/api/auth`, () =>
             HttpResponse.json(


### PR DESCRIPTION
Ved å sette `MOCK_NOTIFICATIONS=empty` i .env, vil man nå kunne se tom varsel-liste.

<img width="595" height="249" alt="image" src="https://github.com/user-attachments/assets/24ff01f7-dfed-4408-a646-af163a96105c" />
