### PR TITLE
XSS JSON script injection

### DIFF
--- a/packages/server/src/views/scripts.ts
+++ b/packages/server/src/views/scripts.ts
@@ -82,7 +82,8 @@ export const ScriptsTemplate = (props: DecoratorDataProps): Template => {
         </script>
         <script id="d-data-parser">
             window.__DECORATOR_DATA__ = JSON.parse(
-                document.getElementById("__DECORATOR_DATA__")?.innerHTML ?? "",
+                document.getElementById("__DECORATOR_DATA__")?.textContent ??
+                    "",
             );
         </script>
 

--- a/packages/shared/html.ts
+++ b/packages/shared/html.ts
@@ -104,7 +104,15 @@ const html = (
     },
 });
 
-export const json = (value: any): Template => unsafeHtml(JSON.stringify(value));
+export const json = (value: unknown): Template =>
+    unsafeHtml(
+        JSON.stringify(value)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e")
+            .replace(/&/g, "\\u0026")
+            .replace(/\u2028/g, "\\u2028")
+            .replace(/\u2029/g, "\\u2029"),
+    );
 
 export const unsafeHtml = (htmlString: string) => ({
     render: () => htmlString,

--- a/packages/shared/test/html.test.ts
+++ b/packages/shared/test/html.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import html from "../html";
+import html, { json } from "../html";
 
 describe("html template tag", () => {
     it("escapes HTML variables to avoid XSS", () => {
@@ -29,5 +29,60 @@ describe("html template tag", () => {
         expect(output.render({ language: "nb" })).toEqual(
             `<script>alert('not an XSS attack!');</script>`,
         );
+    });
+});
+
+describe("json", () => {
+    it("escapes </script> to prevent breaking out of script tags (reflected XSS)", () => {
+        const maliciousPageTitle =
+            "</script><script>alert(document.domain)</script>";
+        const output = json({ pageTitle: maliciousPageTitle }).render({
+            language: "nb",
+        });
+
+        expect(output).not.toContain("</script>");
+        expect(output).not.toContain("<script>");
+        expect(output).toContain("\\u003c/script\\u003e");
+        expect(output).toContain("\\u003cscript\\u003e");
+    });
+
+    it("escapes < and > in JSON values", () => {
+        const output = json({ value: "<b>test</b>" }).render({
+            language: "nb",
+        });
+
+        expect(output).toContain("\\u003cb\\u003etest\\u003c/b\\u003e");
+        expect(output).not.toContain("<b>");
+    });
+
+    it("escapes & in JSON values", () => {
+        const output = json({ value: "foo & bar" }).render({ language: "nb" });
+
+        expect(output).toContain("\\u0026");
+        expect(output).not.toContain(" & ");
+    });
+
+    it("escapes Unicode line separators (\\u2028 and \\u2029) to prevent JS string literal breakage", () => {
+        const output = json({ value: "line\u2028break\u2029end" }).render({
+            language: "nb",
+        });
+
+        expect(output).not.toContain("\u2028");
+        expect(output).not.toContain("\u2029");
+        expect(output).toContain("\\u2028");
+        expect(output).toContain("\\u2029");
+    });
+
+    it("produces valid JSON after escaping", () => {
+        const data = {
+            pageTitle: "</script><script>alert(1)</script>",
+            count: 42,
+        };
+        const output = json(data).render({ language: "nb" });
+
+        expect(() => JSON.parse(output)).not.toThrow();
+        const parsed = JSON.parse(output);
+        expect(parsed.pageTitle).toEqual(data.pageTitle);
+        expect(parsed.count).toEqual(42);
     });
 });


### PR DESCRIPTION
## `packages/shared/html.ts` — `json()`  

   Escaper nå 5 tegn:                                                                                    
`<` -> `\u003c` | Hindrer `</script>` fra å bryte ut av script-taggen
`>` -> `\u003e` | Hindrer `</script>` fra å bryte ut av script-taggen
 `&` -> `\u0026` | Hindrer HTML-entity-tolkning i XHTML/XML-servere
U+2028 -> `\u2028` | LINE SEPARATOR — bryter JS string literals i eldre JS-engines og noen minifiers 
U+2029 -> `\u2029` | PARAGRAPH SEPARATOR — samme

## `packages/server/src/views/scripts.ts`
`innerHTML` → `textContent` i `d-data-parser`. For `<script>`-elementer er de ekvivalente per HTML-spec, men `textContent` er semantisk riktig og fjerner avhengigheten av nettlesers `innerHTML`-serialiseringsatferd.