### PR TITLE
La til keepalive slik at post-kall ikke blir kansellert ved navigasjon

### DIFF
--- a/packages/client/src/views/notifications.ts
+++ b/packages/client/src/views/notifications.ts
@@ -67,6 +67,7 @@ class LinkNotification extends HTMLElement {
                     {
                         method: "POST",
                         credentials: "include",
+                        keepalive: true,
                     },
                 ).then((res) => {
                     if (!res.ok) {


### PR DESCRIPTION
Case med race condition mellom navigasjon på link og post-kall for å inaktivere en beskjed. Ser ut som det påvirket mest Firefox og dev-miljø. 
