### PR TITLE
Justert outline for focus-visible i footer

### DIFF
--- a/packages/client/src/styles/screenshare-button.module.css
+++ b/packages/client/src/styles/screenshare-button.module.css
@@ -9,7 +9,6 @@
     gap: var(--ax-space-8);
     align-items: center;
     text-decoration: underline;
-    text-decoration-color: #99c4dd;
     text-decoration-thickness: 0.0625em;
     text-underline-offset: 0.15em;
     padding: var(--ax-space-8);

--- a/packages/client/src/styles/screenshare-button.module.css
+++ b/packages/client/src/styles/screenshare-button.module.css
@@ -1,6 +1,5 @@
 .screenshareButton {
     background: none;
-    padding: 0;
     margin: 0;
     font: inherit;
     cursor: pointer;
@@ -13,16 +12,12 @@
     text-decoration-color: #99c4dd;
     text-decoration-thickness: 0.0625em;
     text-underline-offset: 0.15em;
-    padding-block: 0.5625rem;
+    padding: 0.5625rem;
     border: 1px solid transparent;
 }
-
-.screenshareButton:hover {
-    text-decoration: none;
-}
-
 .screenshareButton:focus-visible {
-    outline: none;
+    outline: 3px solid;
+    border-radius: 3px;
 }
 
 [data-theme="dark"] .screenshareButton {
@@ -44,7 +39,7 @@
 }
 
 [data-theme="dark"] .screenshareButton:focus-visible {
-    outline: 3px solid #99c3ff;
+    outline-color: #99c3ff;
 }
 
 [data-theme="dark"] .screenshareButton:active {

--- a/packages/client/src/styles/screenshare-button.module.css
+++ b/packages/client/src/styles/screenshare-button.module.css
@@ -12,7 +12,7 @@
     text-decoration-color: #99c4dd;
     text-decoration-thickness: 0.0625em;
     text-underline-offset: 0.15em;
-    padding: 0.5625rem;
+    padding: var(--ax-space-8);
     border: 1px solid transparent;
 }
 .screenshareButton:focus-visible {

--- a/packages/client/src/styles/screenshare-button.module.css
+++ b/packages/client/src/styles/screenshare-button.module.css
@@ -38,7 +38,7 @@
 }
 
 [data-theme="dark"] .screenshareButton:focus-visible {
-    outline-color: #99c3ff;
+    outline-color: var(--ax-info-400);
 }
 
 [data-theme="dark"] .screenshareButton:active {

--- a/packages/client/src/styles/screenshare-button.module.css
+++ b/packages/client/src/styles/screenshare-button.module.css
@@ -17,7 +17,7 @@
 }
 .screenshareButton:focus-visible {
     outline: 3px solid;
-    border-radius: 3px;
+    border-radius: var(--ax-radius-4);
 }
 
 [data-theme="dark"] .screenshareButton {

--- a/packages/client/src/styles/simple-footer.module.css
+++ b/packages/client/src/styles/simple-footer.module.css
@@ -24,6 +24,9 @@
     flex-direction: column;
     align-items: flex-start;
 }
+.footerLinkList > a:focus-visible {
+    outline-color: initial;
+}
 
 @media (min-width: 48rem) {
     .footerLinkList {


### PR DESCRIPTION
For simple footer:

- Bedre kontrast outline lenker
- Standard outline for knapp Del skjerm med veileder 