### PR TITLE
Åpner qbrick content delivery i CSP

### DIFF
--- a/packages/server/src/content-security-policy.ts
+++ b/packages/server/src/content-security-policy.ts
@@ -23,6 +23,8 @@ const boostChatbot = "*.boost.ai";
 const boostScript = `${clientEnv.BOOST_ENV}.boost.ai`;
 const vimeoPlayer = "player.vimeo.com"; // used for inline videos in the chat client
 const qbrick = "video.qbrick.com"; // used for inline videos in the chat client
+const qbrickNotification = "wss://notification.qbrick.com"; // websocket used by qbrick player
+const qbrickMediaCdn = "*.dna.contentdelivery.net"; // qbrick media delivery network
 const vimeoCdn = "*.vimeocdn.com"; // used for video preview images
 const skyra = "*.skyra.no";
 const taskAnalytics = "*.taskanalytics.com";
@@ -86,6 +88,8 @@ const directives: Partial<CSPDirectives> = {
     "connect-src": [
         navNo,
         uxsignalsApi,
+        qbrick,
+        qbrickNotification,
         boostChatbot,
         vergicScreenSharing,
         puzzelScreenSharing,
@@ -93,6 +97,7 @@ const directives: Partial<CSPDirectives> = {
         skyra,
         taskAnalytics,
     ],
+    "media-src": [navNo, qbrick, qbrickMediaCdn],
 };
 
 const localDirectives = Object.entries(directives).reduce(


### PR DESCRIPTION
Qbrick har endret video delivery, så vi må åpne for mer i CSP. Fikser nå - oppvask senere.