### PR TITLE
Fikser proxying til tidligere versjoner av dekoratøren

### DIFF
--- a/packages/server/src/handlers/version-proxy.ts
+++ b/packages/server/src/handlers/version-proxy.ts
@@ -28,22 +28,24 @@ const fetchFromInternalVersionApp = async (
     );
 
     try {
-        request.raw.headers.set(LOOPBACK_HEADER, "true");
-
-        logger.info(
-            `Proxy debug - method: ${request.method}, host-header: ${request.raw.headers.get("host")}, body: ${request.raw.body === null ? "null" : "stream"}`,
-        );
+        const headers = new Headers(request.raw.headers);
+        headers.set(LOOPBACK_HEADER, "true");
 
         const response = await fetch(url, {
             method: request.method,
-            headers: request.raw.headers,
+            headers,
             body: request.raw.body,
         });
 
-        // This header won't always match what we actually return in our response and can cause client errors
-        response.headers.delete("content-encoding");
+        // Clone response headers since they're immutable in Node 24
+        const responseHeaders = new Headers(response.headers);
+        responseHeaders.delete("content-encoding");
 
-        return new Response(response.body, response);
+        return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: responseHeaders,
+        });
     } catch (e: unknown) {
         const err = e instanceof Error ? e : new Error(String(e));
         logger.error(`Proxy request failed for ${url}`, {
@@ -57,7 +59,8 @@ const fetchFromInternalVersionApp = async (
                               message: err.cause.message,
                               code: (err.cause as NodeJS.ErrnoException).code,
                           }
-                        : err.cause,
+                        : String(err.cause),
+                stack: err.stack?.split("\n").slice(0, 3).join(" | "),
             }),
         });
         return null;

--- a/packages/server/src/handlers/version-proxy.ts
+++ b/packages/server/src/handlers/version-proxy.ts
@@ -24,11 +24,15 @@ const fetchFromInternalVersionApp = async (
     const url = urlObj.toString();
 
     logger.info(
-        `Proxy request to: ${urlObj.host}${urlObj.pathname} - Referer: ${request.header("referer")}`,
+        `Proxy request to: ${urlObj.protocol}//${urlObj.host}${urlObj.pathname} - Referer: ${request.header("referer")}`,
     );
 
     try {
         request.raw.headers.set(LOOPBACK_HEADER, "true");
+
+        logger.info(
+            `Proxy debug - method: ${request.method}, host-header: ${request.raw.headers.get("host")}, body: ${request.raw.body === null ? "null" : "stream"}`,
+        );
 
         const response = await fetch(url, {
             method: request.method,
@@ -40,8 +44,22 @@ const fetchFromInternalVersionApp = async (
         response.headers.delete("content-encoding");
 
         return new Response(response.body, response);
-    } catch (e) {
-        logger.error(`Proxy request failed for ${url}`, { error: e });
+    } catch (e: unknown) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        logger.error(`Proxy request failed for ${url}`, {
+            error: JSON.stringify({
+                message: err.message,
+                name: err.name,
+                code: (err as NodeJS.ErrnoException).code,
+                cause:
+                    err.cause instanceof Error
+                        ? {
+                              message: err.cause.message,
+                              code: (err.cause as NodeJS.ErrnoException).code,
+                          }
+                        : err.cause,
+            }),
+        });
         return null;
     }
 };


### PR DESCRIPTION
Etter overgang til Node 24 så er headers i request-objekter immutable. Koden forsøkte å endre headeren direkte som gjorde at hele logikken som skulle hente proxy-versjonen kastet feil.

Fikset nå. I tillegg har jeg lagt på detaljer i error hvis en slik feil skjer igjen, så blir det lettere å se hva som er galt.