### PR TITLE
rename suppress vars, add ssr for menu always

### DIFF
--- a/packages/client/src/analytics/analytics.test.ts
+++ b/packages/client/src/analytics/analytics.test.ts
@@ -42,7 +42,6 @@ const setupDecoratorData = () => {
             shareScreen: true,
             logoutWarning: true,
             feedback: false,
-            ssrMainMenu: false,
             redirectOnUserChange: false,
             analyticsQueryParams: [],
             analyticsRedactFilter: [],

--- a/packages/client/src/params.test.ts
+++ b/packages/client/src/params.test.ts
@@ -21,7 +21,6 @@ describe("updateDecoratorParams", () => {
                 feedback: false,
                 shareScreen: true,
                 logoutWarning: true,
-                ssrMainMenu: false,
                 redirectOnUserChange: false,
                 analyticsQueryParams: [],
                 analyticsRedactFilter: [],

--- a/packages/client/src/views/main-menu.ts
+++ b/packages/client/src/views/main-menu.ts
@@ -8,10 +8,12 @@ import { logger } from "decorator-shared/logger";
 import { CustomEvents } from "../events";
 
 const TEN_MIN_MS = 10 * 60 * 1000;
+const TEN_SECONDS_MS = 10 * 1000;
 
 class MainMenu extends HTMLElement {
     private readonly responseCache = new ResponseCache<string>({
         ttl: TEN_MIN_MS,
+        suppressRetryForMs: TEN_SECONDS_MS,
     });
 
     private async fetchMenuContent(context: Context) {
@@ -51,9 +53,7 @@ class MainMenu extends HTMLElement {
     connectedCallback() {
         window.addEventListener("paramsupdated", this.handleParamsUpdated);
 
-        if (!param("ssrMainMenu")) {
-            this.updateMenuContent(param("context"));
-        }
+        this.updateMenuContent(param("context"));
 
         this.addEventListener(
             "click",

--- a/packages/server/src/menu/main-menu.ts
+++ b/packages/server/src/menu/main-menu.ts
@@ -14,12 +14,11 @@ type MainMenu = z.infer<typeof mainmenuSchema>;
 const MENU_SERVICE_URL = `${env.ENONICXP_SERVICES}/no.nav.navno/menu`;
 
 const ONE_MINUTE_MS = 60 * 1000;
-
-const TWO_MINUTES_MS = 2 * 60 * 1000;
+const TEN_SECONDS_MS = 10 * 1000;
 
 const menuCache = new ResponseCache<MainMenu>({
     ttl: ONE_MINUTE_MS,
-    errorRetryDelay: TWO_MINUTES_MS,
+    suppressRetryForMs: TEN_SECONDS_MS,
 });
 
 const baseMainMenuNode = z.object({

--- a/packages/server/src/views/header/header.ts
+++ b/packages/server/src/views/header/header.ts
@@ -52,9 +52,7 @@ export const HeaderTemplate = async ({
                   contextLinks: makeContextLinks(language),
                   context,
                   language,
-                  mainMenu: params.ssrMainMenu
-                      ? await MainMenuTemplate({ data: params })
-                      : null,
+                  mainMenu: await MainMenuTemplate({ data: params }),
               })}
     `;
 

--- a/packages/shared/params.ts
+++ b/packages/shared/params.ts
@@ -86,7 +86,6 @@ export const paramsSchema = z.object({
     logoutUrl: z.optional(z.string().refine(isValidNavUrl)).catch(undefined),
     logoutWarning: z.boolean().default(true),
     bedrift: z.string().optional(),
-    ssrMainMenu: z.boolean().default(false),
     redirectOnUserChange: z.boolean().default(false),
     pageType: z.string().optional(),
     pageTheme: z.string().optional(),

--- a/packages/shared/response-cache.ts
+++ b/packages/shared/response-cache.ts
@@ -8,35 +8,35 @@ type CacheItem<Type> = {
 // This cache returns a stale value (if it exists), while revalidating
 // the requested value in the background.
 
-// If the callback fails, retries are suppressed for `errorRetryDelay` ms to
+// If the callback fails, retries are suppressed for `suppressRetryForMs` ms to
 // avoid flooding logs and downstream services (e.g. during a rolling deploy).
 // Stale data is served during the backoff window.
 export class ResponseCache<ValueType = unknown> {
     private readonly ttl: number;
-    private readonly errorRetryDelay: number;
+    private readonly suppressRetryForMs: number;
     private readonly cache = new Map<string, CacheItem<ValueType>>();
     private readonly pendingPromises = new Map<
         string,
         Promise<ValueType | null>
     >();
-    private readonly nextRetryAfter = new Map<string, number>();
+    private readonly nextRetryAt = new Map<string, number>();
 
     constructor({
         ttl,
-        errorRetryDelay = 0,
+        suppressRetryForMs = 0,
     }: {
         ttl: number;
-        errorRetryDelay?: number;
+        suppressRetryForMs?: number;
     }) {
         this.ttl = ttl;
-        this.errorRetryDelay = errorRetryDelay;
+        this.suppressRetryForMs = suppressRetryForMs;
         caches.push(this);
     }
 
     clear() {
         this.cache.clear();
         this.pendingPromises.clear();
-        this.nextRetryAfter.clear();
+        this.nextRetryAt.clear();
     }
 
     async get(
@@ -49,8 +49,13 @@ export class ResponseCache<ValueType = unknown> {
             return cachedItem.value;
         }
 
-        const retryAfter = this.nextRetryAfter.get(key);
+        const retryAfter = this.nextRetryAt.get(key);
         if (retryAfter && retryAfter > Date.now()) {
+            logger.warn(
+                `Retry suppressed for key ${key} until ${new Date(
+                    retryAfter,
+                ).toISOString()}`,
+            );
             return cachedItem?.value ?? null;
         }
 
@@ -74,7 +79,7 @@ export class ResponseCache<ValueType = unknown> {
                     throw Error("No value returned from callback");
                 }
 
-                this.nextRetryAfter.delete(key);
+                this.nextRetryAt.delete(key);
                 this.cache.set(key, { value, expires: Date.now() + this.ttl });
                 return value;
             })
@@ -83,10 +88,10 @@ export class ResponseCache<ValueType = unknown> {
                     `Callback error while fetching value for key ${key}`,
                     { error: e },
                 );
-                if (this.errorRetryDelay > 0) {
-                    this.nextRetryAfter.set(
+                if (this.suppressRetryForMs > 0) {
+                    this.nextRetryAt.set(
                         key,
-                        Date.now() + this.errorRetryDelay,
+                        Date.now() + this.suppressRetryForMs,
                     );
                 }
                 return this.cache.get(key)?.value ?? null;

--- a/packages/shared/test/response-cache.test.ts
+++ b/packages/shared/test/response-cache.test.ts
@@ -11,7 +11,7 @@ const flushPromises = async () => {
 };
 
 const makeCache = () =>
-    new ResponseCache<string>({ ttl: 60_000, errorRetryDelay: 120_000 });
+    new ResponseCache<string>({ ttl: 60_000, suppressRetryForMs: 120_000 });
 
 const setupBackoffState = async (
     cache: ResponseCache<string>,
@@ -23,7 +23,7 @@ const setupBackoffState = async (
     await flushPromises();
 };
 
-describe("ResponseCache with errorRetryDelay", () => {
+describe("ResponseCache with suppressRetryForMs", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         clearCache();
@@ -46,7 +46,7 @@ describe("ResponseCache with errorRetryDelay", () => {
     test("returns empty string on success", async () => {
         const cache = new ResponseCache<string>({
             ttl: 60_000,
-            errorRetryDelay: 120_000,
+            suppressRetryForMs: 120_000,
         });
         const callback = vi.fn().mockResolvedValue("");
 
@@ -127,7 +127,7 @@ describe("ResponseCache with errorRetryDelay", () => {
         expect(result).toBe("fresh-data");
     });
 
-    test("without errorRetryDelay, allows retry on next request after failure", async () => {
+    test("without suppressRetryForMs, allows retry on next request after failure", async () => {
         const cache = new ResponseCache<string>({ ttl: 60_000 });
         const callback = vi
             .fn()
@@ -147,7 +147,7 @@ describe("ResponseCache with errorRetryDelay", () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    test("clears nextRetryAfter on successful refetch", async () => {
+    test("clears nextRetryAt on successful refetch", async () => {
         const cache = makeCache();
         const callback = vi
             .fn()


### PR DESCRIPTION
Fjerner ssrMenu-parameteret ettersom det ikke brukes av noen, og legger inn at vi alltid forsøker å fetche meny på serversida, så vi minimerer risiko for å ikke få noen meny.

Endrer også litt navngiving i caching:
- `errorRetryDelay` -> `suppressRetryForMs`, denne variabelen sier at vi skal vente i X antall MS å hente verdi på nytt hvis man får en error fra server. Setter også denne ned til 10ms for henting av meny.
- `nextRetryAfter`-> `nextRetryAt`, denne sier noe om hvilket klokkeslett som må passeres for at vi skal prøve å hente på nytt, og regnes ut av Date.now() + suppressRetryForMs. 

Ønsker ekstra øye på navn og  om man er uenig i å fjerne det ubrukte ssrMenu-parameteret.