### PR TITLE
Legg til Playwright-tester for Umami-sporingseventer

### DIFF
--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,0 +1,83 @@
+import { expect, Page } from "@playwright/test";
+import { testWithUmamiMock } from "./fixtures";
+
+const setBreadcrumbs = (
+    page: Page,
+    breadcrumbs: {
+        title: string;
+        analyticsTitle?: string;
+        url: string;
+        handleInApp: boolean;
+    }[],
+) =>
+    page.evaluate((breadcrumbs) => {
+        window.postMessage({
+            source: "decoratorClient",
+            event: "params",
+            payload: { breadcrumbs },
+        });
+    }, breadcrumbs);
+
+const clickBreadcrumbAndGetUmamiEvent = async (page: Page) => {
+    // Start polling for the Breadcrumbs event before clicking
+    const eventHandle = page.waitForFunction(() => {
+        const events: any[] = (window as any).__umami_captured__ ?? [];
+        return events.find((e: any) => e?.data?.komponent === "Breadcrumbs");
+    });
+
+    await page.getByText("Ola Nordmann").click();
+
+    const handle = await eventHandle;
+    return handle.jsonValue();
+};
+
+testWithUmamiMock(
+    "Breadcrumbs without analyticsTitle should send [redacted] as lenketekst",
+    async ({ page }) => {
+        await setBreadcrumbs(page, [
+            {
+                title: "Ola Nordmann",
+                url: "/syk/sykmeldinger/foo",
+                handleInApp: true,
+            },
+            {
+                title: "Mine sykmeldinger",
+                url: "/syk/sykmeldinger/foo/bar",
+                handleInApp: true,
+            },
+        ]);
+
+        await page.getByTestId("consent-banner-all").click();
+
+        const event = await clickBreadcrumbAndGetUmamiEvent(page);
+
+        expect(event.data.lenketekst).toBe("[redacted]");
+        expect(event.data.lenketekst).not.toContain("Ola Nordmann");
+    },
+);
+
+testWithUmamiMock(
+    "Breadcrumbs with analyticsTitle should use analyticsTitle as lenketekst",
+    async ({ page }) => {
+        await setBreadcrumbs(page, [
+            {
+                title: "Ola Nordmann",
+                analyticsTitle: "Min analytics title",
+                url: "/syk/sykmeldinger/foo",
+                handleInApp: true,
+            },
+            {
+                title: "Mine sykmeldinger",
+                url: "/syk/sykmeldinger/foo/bar",
+                handleInApp: true,
+            },
+        ]);
+
+        await page.getByTestId("consent-banner-all").click();
+
+        const event = await clickBreadcrumbAndGetUmamiEvent(page);
+
+        expect(event.data.lenketekst).toBe("Min analytics title");
+        expect(event.data.lenketekst).not.toContain("Ola Nordmann");
+    },
+);

--- a/tests/decorator-utils.spec.ts
+++ b/tests/decorator-utils.spec.ts
@@ -64,5 +64,3 @@ test("decorator utils", async ({ page }) => {
         handleInApp: true,
     });
 });
-//TODO: Lage tester for Umami tilsvarende tester for Amplitude, som nå er fjernet
-// Se opprinnelig Amplitude-test her: https://github.com/navikt/nav-dekoratoren/blob/144a33f376f41ac67c0b0ca6eb70106712298fe8/tests/decorator-utils.spec.ts#L68

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,5 +1,33 @@
 import { Page, test as base } from "@playwright/test";
 
+export const setupUmamiMock = async (page: Page) => {
+    await page.addInitScript(() => {
+        const captured: any[] = [];
+        (window as any).__umami_captured__ = captured;
+
+        // Prevent the real Umami script from overwriting the mock
+        Object.defineProperty(window, "umami", {
+            get: () => ({
+                track: (fn: (props: any) => any) => {
+                    const event = fn({
+                        hostname: window.location.hostname,
+                        title: document.title,
+                        url: window.location.pathname,
+                        referrer: document.referrer,
+                        language: navigator.language,
+                        screen: `${screen.width}x${screen.height}`,
+                        website: "test",
+                    });
+                    captured.push(event);
+                    return Promise.resolve(event);
+                },
+            }),
+            set: () => {},
+            configurable: true,
+        });
+    });
+};
+
 const decoratorReady = () =>
     new Promise<void>((resolve) => {
         window.addEventListener("message", (e) => {
@@ -53,6 +81,46 @@ export const test = (
         { test: csr, name: "csr" },
         { test: ssr, name: "ssr" },
         { test: nextPagesRouter, name: "next pages router" },
+    ].forEach(({ test, name: fixtureName }) =>
+        test(`${fixtureName}: ${name}`, fn),
+    );
+};
+
+const ssrWithUmamiMock = base.extend({
+    page: async ({ page }, use) => {
+        await setupUmamiMock(page);
+        await page.goto("http://localhost:8089");
+        await page.evaluate(decoratorReady);
+        await use(page);
+    },
+});
+
+const csrWithUmamiMock = base.extend({
+    page: async ({ page }, use) => {
+        await setupUmamiMock(page);
+        await page.goto("http://localhost:8080/csr.html");
+        await page.evaluate(decoratorReady);
+        await use(page);
+    },
+});
+
+const nextPagesRouterWithUmamiMock = base.extend({
+    page: async ({ page }, use) => {
+        await setupUmamiMock(page);
+        await page.goto("http://localhost:3000");
+        await page.evaluate(decoratorReady);
+        await use(page);
+    },
+});
+
+export const testWithUmamiMock = (
+    name: string,
+    fn: (args: { page: Page }) => Promise<void>,
+) => {
+    [
+        { test: csrWithUmamiMock, name: "csr" },
+        { test: ssrWithUmamiMock, name: "ssr" },
+        { test: nextPagesRouterWithUmamiMock, name: "next pages router" },
     ].forEach(({ test, name: fixtureName }) =>
         test(`${fixtureName}: ${name}`, fn),
     );


### PR DESCRIPTION
Implementerer Playwright-tester etter at testene for Amplitude ble fjernet ([#666](https://github.com/navikt/nav-dekoratoren/pull/666)).

I stedet for å intercepte nettverkskall (slik Amplitude-testene gjorde mot  amplitude.nav.no/collect ), mockes `window.umami`  direkte via `page.addInitScript()`. Dette gjør testene uavhengige av at `UMAMI_SCRIPT_URL` og `UMAMI_PROXY_HOST` er satt i testmiljøet.    

Hva som er testet:
- Breadcrumb-klikk uten `analyticsTitle` →  lenketekst  er `[redacted]`  (PII-beskyttelse)
- Breadcrumb-klikk med `analyticsTitle` →  lenketekst  er den oppgitte analytics-tittelen