### PR TITLE
Avvikle next begrepet

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -31,7 +31,7 @@ inputs:
   CDN_DESTINATION:
     description: Destination path on CDN
     required: false
-    default: "/decorator-next"
+    default: "/nav-dekoratoren"
 
 outputs:
   IMAGE:

--- a/.nais/unleash-api-token.dev.yml
+++ b/.nais/unleash-api-token.dev.yml
@@ -1,7 +1,7 @@
 apiVersion: unleash.nais.io/v1
 kind: ApiToken
 metadata:
-  name: decorator-next
+  name: nav-dekoratoren
   namespace: personbruker
   labels:
     team: personbruker
@@ -10,5 +10,5 @@ spec:
     apiVersion: unleash.nais.io/v1
     kind: RemoteUnleash
     name: navno
-  secretName: decorator-next-unleash-api-token
+  secretName: nav-dekoratoren-unleash-api-token
   environment: development

--- a/.nais/unleash-api-token.prod.yml
+++ b/.nais/unleash-api-token.prod.yml
@@ -1,7 +1,7 @@
 apiVersion: unleash.nais.io/v1
 kind: ApiToken
 metadata:
-  name: decorator-next
+  name: nav-dekoratoren
   namespace: personbruker
   labels:
     team: personbruker
@@ -10,5 +10,5 @@ spec:
     apiVersion: unleash.nais.io/v1
     kind: RemoteUnleash
     name: navno
-  secretName: decorator-next-unleash-api-token
+  secretName: nav-dekoratoren-unleash-api-token
   environment: production

--- a/.nais/vars/dev-beta-navno.yml
+++ b/.nais/vars/dev-beta-navno.yml
@@ -13,7 +13,7 @@ env:
   - name: APP_URL
     value: https://dekoratoren-beta.intern.dev.nav.no
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next/public
+    value: https://cdn.nav.no/personbruker/nav-dekoratoren/public
   - name: ENONICXP_SERVICES
     value: https://www-q6.nav.no/_/service
   - name: SEARCH_API_URL

--- a/.nais/vars/dev-beta-tms.yml
+++ b/.nais/vars/dev-beta-tms.yml
@@ -13,7 +13,7 @@ env:
   - name: APP_URL
     value: https://dekoratoren-beta-tms.intern.dev.nav.no
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next/public
+    value: https://cdn.nav.no/personbruker/nav-dekoratoren/public
   - name: ENONICXP_SERVICES
     value: https://www-q6.nav.no/_/service
   - name: SEARCH_API_URL

--- a/.nais/vars/dev-stable.yml
+++ b/.nais/vars/dev-stable.yml
@@ -14,7 +14,7 @@ env:
   - name: APP_URL
     value: https://dekoratoren.ekstern.dev.nav.no
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next/public
+    value: https://cdn.nav.no/personbruker/nav-dekoratoren/public
   - name: ENONICXP_SERVICES
     value: https://www.dev.nav.no/_/service
   - name: SEARCH_API_URL

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -13,7 +13,7 @@ env:
   - name: APP_URL
     value: https://www.nav.no/dekoratoren
   - name: CDN_URL
-    value: https://cdn.nav.no/personbruker/decorator-next/public
+    value: https://cdn.nav.no/personbruker/nav-dekoratoren/public
   - name: ENONICXP_SERVICES
     value: https://www.nav.no/_/service
   - name: SEARCH_API_URL

--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ ikke.
 Du kan finne det nåværende CSP-direktivet
 på [https://www.nav.no/dekoratoren/api/csp](https://www.nav.no/dekoratoren/api/csp). Du kan også
 inspisere den faktiske koden
-på [content-security-policy.ts](https://github.com/navikt/decorator-next/blob/main/packages/server/src/content-security-policy.ts)
+på [content-security-policy.ts](https://github.com/navikt/nav-dekoratoren/blob/main/packages/server/src/content-security-policy.ts)
 for en bedre forståelse av hvordan CSP fungerer.
 
 [`@navikt/nav-dekoratoren-moduler`](https://github.com/navikt/nav-dekoratoren-moduler) pakken tilbyr

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "decorator-next",
+    "name": "nav-dekoratoren",
     "private": "true",
     "version": "0.0.1",
     "description": "",

--- a/packages/client/src/csr.ts
+++ b/packages/client/src/csr.ts
@@ -5,7 +5,7 @@ const findOrError = (id: string) => {
     const el = document.getElementById(`decorator-${id}`);
 
     if (!el) {
-        throw new Error(`No elem:${id}. See github.com/navikt/decorator-next`);
+        throw new Error(`No elem:${id}. See github.com/navikt/nav-dekoratoren`);
     }
 
     return el;

--- a/packages/server/public/site2.webmanifest
+++ b/packages/server/public/site2.webmanifest
@@ -3,12 +3,12 @@
     "short_name": "nav.no",
     "icons": [
         {
-            "src": "//cdn.nav.no/personbruker/decorator-next/public/android-chrome-192x192.png",
+            "src": "//cdn.nav.no/personbruker/nav-dekoratoren/public/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "//cdn.nav.no/personbruker/decorator-next/public/android-chrome-512x512.png",
+            "src": "//cdn.nav.no/personbruker/nav-dekoratoren/public/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -227,7 +227,6 @@ app.get("/", async ({ req, html }) =>
     ),
 );
 
-app.route("/decorator-next", app);
 app.route("/dekoratoren", app);
 app.route("/common-html/v4/navno", app);
 

--- a/packages/server/src/views/splash-page.ts
+++ b/packages/server/src/views/splash-page.ts
@@ -6,23 +6,24 @@ import cls from "decorator-client/src/styles/splash-page.module.css";
 function SplashPage() {
     return html`
         <div class="${cls.splashPage}">
-            <h1>Decorator next</h1>
+            <h1>Nav Dekoratøren</h1>
             <div class="${cls.splashAlert}">
                 <span>
-                    Hei! Dette er en intern test-side for header og footer på
-                    nav.no. <a href="https://www.nav.no">Gå til forsiden</a>.
+                    Dette er en intern test-side for header og footer på nav.no.
+                    <a href="https://www.nav.no">Gå til forsiden</a>.
                 </span>
             </div>
         </div>
     `;
 }
 
-const domainsToShow = ["localhost", "decorator-next"] as const;
+const allowedHosts = ["localhost", "nav.no"] as const;
 
-export const getSplashPage = (origin: string) =>
-    match(origin)
+export const getSplashPage = (urlOrigin: string) =>
+    match(urlOrigin)
         .when(
-            (origin) => domainsToShow.some((domain) => origin.includes(domain)),
+            (urlOrigin) =>
+                allowedHosts.some((host) => urlOrigin.includes(host)),
             SplashPage,
         )
         .otherwise(() => undefined);


### PR DESCRIPTION
decorator-next var en uheldig navngivning fra da vi bygget den nye dekoratøren. Foreslår å avvikle den.

**Henvisning til favicon i cdn ✅ :**
https://cdn.nav.no/personbruker/decorator-next/public/favicon.ico henvises til av 6 apper. Disse vil fortsatt fungere fordi cdn ikke aktivt slettes.

**app.route("/decorator-next", app) ✅ :**
Jeg har kikket rundt, men kan ikke se at noen forsøker å kalle /decorator-next som route.

**Pensjonskalkulator 🤷 :**
Lenker direkte til en css-bundle som er uheldig: https://github.com/navikt/pensjonskalkulator-frontend-monorepo/blob/859f98cec618e99a0522833e6192bcfea5dc4448/packages/mocks/src/data/decorator-env-features.json#L54

**Klang 🤷 :**
[Henviser til https://decorator-next.ekstern.dev.nav.no og https://www.nav.no/decorator-next ](https://github.com/navikt/klang/blob/f9848dd4df16344ac8251036cdba54e5a0fcf8cb/server/src/nav-dekoratoren/urls.ts#L16)som ikke fungerer i dag heller.

**Error 500 ☑️ :**
Denne må oppdateres etter deploy: https://github.com/navikt/team-navno/blob/2df51a9194a62c598be1736478fe129481df9bf2/error5xx.html#L11


**Frontend docker-compose ☑️ :**
Henviser til imaget decorator-next, så den må oppdateres. https://github.com/navikt/nav-enonicxp-frontend.

**Foreldrepengesoknad ☑️ :**
Bør varsle de om å endre oppføringen i FEIL_VI_VIL_LUKE_BORT: https://github.com/navikt/foreldrepengesoknad/blob/d5cf7e18962b03212c4f75d4cb1cd841e6963b51/packages/observability/src/filterUtils.ts#L5


